### PR TITLE
add holy days of obligation to ApiOptions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,4 +1,4 @@
-# This workflow will run publish a package to GitHub Packages when a release is published
+# This workflow will run publish a package to NPMJS when a release is published
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 # See: https://docs.npmjs.com/generating-provenance-statements
 

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,26 @@
+MD013:
+  line_length: 180
+  code_blocks: false
+  tables: false
+MD033:
+  allowed_elements:
+    - img
+    - a
+    - table
+    - thead
+    - tbody
+    - tr
+    - th
+    - td
+    - li
+    - ul
+    - ol
+    - kbd
+    - style
+MD041: false
+MD046:
+  style: fenced
+MD029:
+  style: one
+MD025:
+  front_matter_title: ""

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,6 @@
 {
-    "recommendations": ["unifiedjs.vscode-mdx"]
+    "recommendations": [
+        "unifiedjs.vscode-mdx",
+        "davidanson.vscode-markdownlint"
+    ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+    "recommendations": ["unifiedjs.vscode-mdx"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "mdx.server.enable": true
+}

--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ such as the date of Epiphany, the date of the Ascension, the date of Corpus Chri
 * `_ascensionInput`: a select input with options for when Ascension is celebrated
 * `_corpusChristiInput`: a select input with options for when Corpus Christi is celebrated
 * `_eternalHighPriestInput`: a select input with options for whether Eternal High Priest is celebrated
+* `_holydaysOfObligationInput`: a select input with options for setting Holy Days of Obligation
 
 #### Path builder form control
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # @liturgical-calendar/components-js
-This component library for the Liturgical Calendar API is a collection of reusable frontend components, that work with the Liturgical Calendar API (currently hosted at https://litcal.johnromanodorazio.com/api/dev/).
+
+This component library for the Liturgical Calendar API is a collection of reusable frontend components,
+that work with the Liturgical Calendar API (currently hosted at [https://litcal.johnromanodorazio.com/api/dev/](https://litcal.johnromanodorazio.com/api/dev/)).
 
 You can also use a local instance of the API by passing in the url for your local API instance to the `ApiClient` class static `init()` method.
 
@@ -10,6 +12,7 @@ The components library is written as an ES6 module, so it can be imported using 
 The `@liturgical-calendar/components-js` component library doesn't need to be installed via npm, yarn, or pnpm. Instead, it can be used directly from a CDN that supports ES6 modules.
 
 Example:
+
 ```javascript
 //myScript.js
 import { ApiClient, CalendarSelect, ApiOptions, Input, WebCalendar, Grouping, ColorAs, Column, ColumnOrder, DateFormat, GradeDisplay, CalendarSelectFilter } from 'https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@latest/+esm'
@@ -17,6 +20,7 @@ import { ApiClient, CalendarSelect, ApiOptions, Input, WebCalendar, Grouping, Co
 
 > [!TIP]
 > In order to use ES6 import statements without a build step in your project, your project's script tag must have the attribute `type="module"`:
+>
 > ```html
 > <!-- myPage.html -->
 > <script type="module" src="myScript.js"></script>
@@ -25,10 +29,15 @@ import { ApiClient, CalendarSelect, ApiOptions, Input, WebCalendar, Grouping, Co
 The easiest way to use ES Modules in the browser is by importing directly from a CDN rather than pulling in locally via `yarn`, `npm`, or `pnpm`.
 
 > [!NOTE]
-> The jsdelivr CDN caches the packages for 7 days, so when requesting the `@latest` tag you might not actually get the latest version for another week or so. If you want to implement the most recent release before the CDN cache expires, you should explicitly request the version number instead of the `@latest` tag, e.g. `https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@1.1.0/+esm`.
+> The jsdelivr CDN caches the packages for 7 days, so when requesting the `@latest` tag you might not actually get the latest version for another week or so.
+> If you want to implement the most recent release before the CDN cache expires, you should explicitly request the version number
+> instead of the `@latest` tag, e.g. `https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@1.1.0/+esm`.
+
+<!-- split between blockquotes -->
 
 > [!TIP]
 > You can optionally define an importmap so that you can import from `@liturgical-calendar/components-js` rather than from the full CDN path:
+>
 > ```html
 > <!-- myPage.html -->
 > <script type='importmap'>
@@ -40,25 +49,44 @@ The easiest way to use ES Modules in the browser is by importing directly from a
 > </script>
 > <script type="module" src="myScript.js"></script>
 > ```
+>
 > ```javascript
 > //myScript.js
 > import { ApiClient, CalendarSelect, ApiOptions, Input, WebCalendar, Grouping, ColorAs, Column, ColumnOrder, DateFormat, GradeDisplay, CalendarSelectFilter } from '@liturgical-calendar/components-js'
 > ```
+>
 > The importmap let's the browser know where to look for the `@liturgical-calendar/components-js` package.
 > The importmap must be defined before the script that imports the `@liturgical-calendar/components-js` package.
 > It's recommended to define the importmap in an inline `<script type="importmap">` rather than load it from a separate file,
 > to avoid unnecessary network requests and possible timing conflicts in loading the importmap before any scripts that import the `@liturgical-calendar/components-js` package.
 
-
 ## Storybook
 
-To showcase usage of the components, a storybook is included. Before launching storybook, an instance of the Liturgical Calendar API must be running locally at http://localhost:8000. You can then launch the storybook by running `yarn storybook` (after having installed dependencies with `yarn install`), this will launch the storybook at a random free port  at http://localhost:{PORT}. If you would like to launch storybook on a specific port, you can pass in a port number as a parameter to the `yarn storybook` command, e.g.: `yarn storybook --port 6006`.
+To showcase usage of the components, a storybook is included. Before launching storybook,
+an instance of the Liturgical Calendar API must be running locally at [http://localhost:8000](http://localhost:8000).
+You can then launch the storybook by running `yarn storybook` (after having installed dependencies with `yarn install`),
+this will launch the storybook on a random free port (e.g. `http://localhost:6006`).
+If you would like to launch storybook on a specific port, you can pass in a port number as a parameter to the `yarn storybook` command, e.g.: `yarn storybook --port 6006`.
 
-If you have a running instance of the Liturgical Calendar API on a port other than 8000, you can set the environment variable `STORYBOOK_API_PORT` to the port of your local API instance, e.g.: `STORYBOOK_API_PORT=8092 yarn storybook`. An `.env.example` file is included to assist with this, just copy to `.env` and set the value of `STORYBOOK_API_PORT` to the port of your local API instance, and the environment variable will be automatically picked up by storybook from the `.env` file.
+If you have a running instance of the Liturgical Calendar API on a port other than 8000,
+you can set the environment variable `STORYBOOK_API_PORT` to the port of your local API instance, e.g.: `STORYBOOK_API_PORT=8092 yarn storybook`.
+An `.env.example` file is included to assist with this, just copy to `.env` and set the value of `STORYBOOK_API_PORT` to the port of your local API instance,
+and the environment variable will be automatically picked up by storybook from the `.env` file.
 
-To simplify getting a running instance of the Liturgical Calendar API on your local machine, you can use a docker container. This way you don't have to worry about setting up PHP with the required packages, composer installing the API, and launching the API with the required environment variables. Just simply build the docker image from the provided [Dockerfile](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/blob/development/Dockerfile) in the Liturgical Calendar API repository. To simplify this even further, you can use the provided [docker-compose.yml](https://github.com/Liturgical-Calendar/liturgy-components-js/blob/main/docker-compose.yml) file to launch both the Liturgical Calendar API and the Liturgical Calendar Components storybook in one command: `docker compose up -d`.
+To simplify getting a running instance of the Liturgical Calendar API on your local machine, you can use a docker container.
+This way you don't have to worry about setting up PHP with the required packages, composer installing the API, and launching the API with the required environment variables.
+Just simply build the docker image from the provided [Dockerfile](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/blob/development/Dockerfile)
+in the Liturgical Calendar API repository.
+To simplify this even further, you can use the provided [docker-compose.yml](https://github.com/Liturgical-Calendar/liturgy-components-js/blob/main/docker-compose.yml) file
+to launch both the Liturgical Calendar API and the Liturgical Calendar Components storybook in one command: `docker compose up -d`.
 
-If you would like to customize the port that the API will be running on, or the port that storybook will be running on, you would again use a `.env` file in the same folder as the `docker-compose.yml` file, and set the value of `STORYBOOK_API_PORT` to the port that you want the API to run on before issuing `docker compose up -d`. Note that in this case, you would also have to mount the `.env` file into the container, otherwise storybook will not see the environment variable, see the comments in [docker-compose.yml](https://github.com/Liturgical-Calendar/liturgy-components-js/blob/main/docker-compose.yml). Note that the images that are built will be about 1.09GB and 657MB respectively, for a total of 1.76GB.
+If you would like to customize the port that the API will be running on, or the port that storybook will be running on,
+you would again use a `.env` file in the same folder as the `docker-compose.yml` file,
+and set the value of `STORYBOOK_API_PORT` to the port that you want the API to run on before issuing `docker compose up -d`.
+Note that in this case, you would also have to mount the `.env` file into the container, otherwise storybook will not see the environment variable,
+see the comments in [docker-compose.yml](https://github.com/Liturgical-Calendar/liturgy-components-js/blob/main/docker-compose.yml).
+Note that the images that are built will be about 1.09GB and 657MB respectively, for a total of 1.76GB.
+
 > [!NOTE]
 > While it is often possible to reduce the size of docker images by using multi-stage builds with an alpine image in the last stage,
 > in the case of the Liturgical Calendar API this is not possible due to the need to install system language packages, which are not available in the alpine image.
@@ -66,6 +94,7 @@ If you would like to customize the port that the API will be running on, or the 
 ## Components
 
 The `index.js` file of the Liturgical Calendar Components library exports the following components and enums:
+
 ```javascript
 export {
     ApiClient,
@@ -83,7 +112,8 @@ export {
     GradeDisplay,
     ApiOptionsFilter,
     CalendarSelectFilter,
-    YearType
+    YearType,
+    LatinInterface
 }
 ```
 
@@ -93,11 +123,15 @@ The remaining classes are used either as static classes (`Input`) or as Enums, t
 
 ### ApiClient
 
-The `ApiClient` is not a UI component, but rather takes care of fetching data from the Liturgical Calendar API based on interactions with the UI components and providing the fetched data to the UI components.
+The `ApiClient` is not a UI component, but rather takes care of fetching data from the Liturgical Calendar API based on interactions with the UI components,
+and providing the fetched data to the UI components.
 
-The `ApiClient` must be statically initialized before any UI components can be used, since the UI components depend on the data provided by the ApiClient. By default, the `ApiClient` will initialize itself with the API URL at https://litcal.johnromanodorazio.com/api/dev/, but you can provide a different API URL, whether local or remote, by passing the url as a parameter to the `ApiClient.init()` method.
+The `ApiClient` must be statically initialized before any UI components can be used, since the UI components depend on the data provided by the ApiClient.
+By default, the `ApiClient` will initialize itself with the API URL at [https://litcal.johnromanodorazio.com/api/dev/](https://litcal.johnromanodorazio.com/api/dev/),
+but you can provide a different API URL, whether local or remote, by passing the url as a parameter to the `ApiClient.init()` method (for example: `ApiClient.init('http://localhost:8000')`).
 
-The `ApiClient.init()` method returns a promise that resolves when the metadata about available liturgical calendars has been fetched from the API. The promise will resolve to an instance of the `ApiClient` class if successful, or to false if an error occurs.
+The `ApiClient.init()` method returns a promise that resolves when the metadata about available liturgical calendars has been fetched from the API.
+The promise will resolve to an instance of the `ApiClient` class if successful, or to false if an error occurs.
 
 Example:
 
@@ -136,7 +170,9 @@ ApiClient.init('http://localhost:8000').then((apiClient) => {
 });
 ```
 
-Then every time a new calendar is selected from the Calendar Select dropdown, the API Client will fetch the calendar data from the API. And every time a new API option is selected from the API Options form, the API Client will fetch the new calendar data from the API and emit an internal `calendarFetched` event that a `WebCalendar` component instance can listen to.
+Then every time a new calendar is selected from the Calendar Select dropdown, the API Client will fetch the calendar data from the API.
+And every time a new API option is selected from the API Options form, the API Client will fetch the new calendar data from the API
+and emit an internal `calendarFetched` event that a `WebCalendar` component instance can listen to.
 
 It is also possible to directly fetch calendar data from the API without listening to UI components, by calling one of the following publicly exposed instance methods:
 
@@ -167,28 +203,38 @@ ApiClient.init('http://localhost:8000').then((apiClient) => {
 });
 ```
 
-While the `ApiClient` component will generally be used in conjunction with UI components, it may however be useful to set the `year` or `year_type` parameters directly, without having to depend on interactions with the UI components. For this reason the following chainable instance methods are also provided:
+While the `ApiClient` component will generally be used in conjunction with UI components, it may however be useful to set the `year` or `year_type` parameters directly,
+without having to depend on interactions with the UI components. For this reason the following chainable instance methods are also provided:
+
 * `setYear(year)`: will set the year parameter to the given year
 * `setYearType(yearType)`: will set the yearType parameter to the given `YearType` (you can import the `YearType` enum to assist with this)
 
 The `ApiClient` class exposes the following static readonly class properties:
+
 * `_apiUrl`: the API URL that is being used by the `ApiClient` class
 * `_metadata`: the metadata about available liturgical calendars that has been fetched from the API
 
 And `ApiClient` instances expose the following readonly instance properties:
-* `_eventBus`: an instance of the internal `EventEmitter` class which handles registering listeners and emitting events. The `EventEmitter` class in turn exposes a readonly instance property `_events` which can be used to inspect registered events (such as the `calendarFetched` event, which can be inspected from `_eventBus._events.calendarFetched`)
+
+* `_eventBus`: an instance of the internal `EventEmitter` class which handles registering listeners and emitting events.
+  The `EventEmitter` class in turn exposes a readonly instance property `_events` which can be used to inspect registered events
+  (such as the `calendarFetched` event, which can be inspected from `_eventBus._events.calendarFetched`).
 * `_calendarData`: the JSON data representing the latest fetched calendar data from the API
 
 ### CalendarSelect
 
-The CalendarSelect is a JavaScript class that generates a select element populated with available liturgical calendars from the Liturgical Calendar API. It allows you to easily add a liturgical calendar selector to your website.
+The `CalendarSelect` component generates a select element populated with available liturgical calendars from the Liturgical Calendar API.
+It allows you to easily add a liturgical calendar selector to your website.
 
-The `ApiClient` class must be statically initialized before instantiating the `CalendarSelect` class. This is the only way for the select element to be populated with the current available liturgical calendars, whether national or diocesan.
+The `ApiClient` class must be statically initialized before instantiating the `CalendarSelect` class.
+This is the only way for the select element to be populated with the current available liturgical calendars, whether national or diocesan.
 
 The `CalendarSelect` class can be instantiated with a `locale` parameter, which will determine the localization for the UI elements (display names of the nations for national calendars).
-The default is 'en' (English). Locales with region extensions are also supported, such as 'en-US', 'en-GB', 'en-CA', etc. If the locale has underscores (as is the case with PHP locales), they will be replaced with hyphens.
+The default is 'en' (English). Locales with region extensions are also supported, such as 'en-US', 'en-GB', 'en-CA', etc.
+If the locale has underscores (as is the case with PHP locales), they will be replaced with hyphens.
 
 The `CalendarSelect` class can also be instantiated with an `options` parameter, as an object that can have the following properties:
+
 * `locale`: The locale to use for the `CalendarSelect` UI elements.
 * `id`: The ID of the `CalendarSelect` element.
 * `class`: The class name for the `CalendarSelect` element.
@@ -204,20 +250,24 @@ Likewise, the same properties that can be passed in the `options` object, can al
 
 By default, a `CalendarSelect` instance will be populated with all available national and diocesan calendars (grouped by nation).
 
-It is also possible to filter the options in the select element to only include national calendars or diocesan calendars, by calling the `filter()` method and passing in a value of either `CalendarSelectFilter.NATIONAL_CALENDARS` or `CalendarSelectFilter.DIOCESAN_CALENDARS`.
+It is also possible to filter the options in the select element to only include national calendars or diocesan calendars,
+by calling the `filter()` method and passing in a value of either `CalendarSelectFilter.NATIONAL_CALENDARS` or `CalendarSelectFilter.DIOCESAN_CALENDARS`.
 
 Example:
+
 ```javascript
 import { CalendarSelect, CalendarSelectFilter } from 'https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@latest/+esm';
 const calendarSelect = new CalendarSelect( 'en-US' );
 calendarSelect.filter(CalendarSelectFilter.DIOCESAN_CALENDARS).appendTo( '#calendarOptions');
 ```
 
-The `CalendarSelect` instance is inserted into the DOM by calling the `appendTo(elementSelector)` method, and passing the CSS selector for the element to which the select element should be appended.
+The `CalendarSelect` instance is inserted into the DOM by calling the `appendTo(elementSelector)` method,
+and passing the CSS selector for the element to which the select element should be appended.
 
 All of the `CalendarSelect` configuration methods are chainable, except for the `appendTo()` method which must be called at the end of the chain.
 
 Example:
+
 ```javascript
 const calendarSelect = new CalendarSelect( 'en-US' );
 calendarSelect.allowNull()
@@ -230,88 +280,131 @@ calendarSelect.allowNull()
 ```
 
 The following chainable configuration methods are available on the `CalendarSelect` instance:
+
 * `class( className )`: sets the class or classes to apply to the select element
 * `id( id )`: sets the id to apply to the select element (without an initial '#')
 * `name( name )`: sets the name to apply to the select element (usually the same as the id, not very useful since we probably won't be submitting the form)
 * `label( options )`: configures the <kbd>\<label\></kbd> element for the select element. The options object can have the following properties:
-    * `class`: the class to apply to the label element
-    * `id`: the id to apply to the label element
-    * `text`: the text to use for the label element (default is __'Select a calendar'__)
+  * `class`: the class to apply to the label element
+  * `id`: the id to apply to the label element
+  * `text`: the text to use for the label element (default is __'Select a calendar'__)
 * `wrapper( options )`: configures a wrapper element, which the select element will be wrapped in. The options object can have the following properties:
-    * `as`: the tag name to use for the wrapper element (can be either __'div'__ or __'td'__, default is __'div'__)
-    * `class`: the class to apply to the wrapper element
-    * `id`: the id to apply to the wrapper element
+  * `as`: the tag name to use for the wrapper element (can be either __'div'__ or __'td'__, default is __'div'__)
+  * `class`: the class to apply to the wrapper element
+  * `id`: the id to apply to the wrapper element
 * `disabled( disabled = true )`: sets the `disabled` attribute on the select element based on the boolean value passed in
-* `filter(filter)`: filters the options in the select element to only include national calendars or diocesan calendars. The filter can have a value of either __`CalendarSelectFilter.NATIONAL_CALENDARS`__ , __`CalendarSelectFilter.DIOCESAN_CALENDARS`__, or __`CalendarSelectFilter.NONE`__.
-* `allowNull( allowNull = true )`: sets whether the select element should include an empty option as the first option. If this method is not called, the default is false; if it is called without a parameter, the default is true. Otherwise, the method will take a boolean parameter to set whether the select element should include an empty option as the first option. An empty option corresponds with the General Roman Calendar for the API, since no national or diocesan calendar is selected.
-* `after( htmlString )`: allows to insert HTML content after the select element, for example to add a description below the select element. The HTML content must be a string, and the string is sanitized and stripped of any PHP or JavaScript script tags.
-* `linkToNationsSelect( calendarSelectInstance )`: in case the current `CalendarSelect` instance has the `CalendarSelectFilter.DIOCESAN_CALENDARS` filter applied, this method can be used to link the current CalendarSelect instance to a `CalendarSelectFilter.NATIONAL_CALENDARS` filtered CalendarSelect instance, so that the diocese options of the current CalendarSelect instance will be filtered according to the selected nation in the linked CalendarSelect instance.
+* `filter(filter)`: filters the options in the select element to only include national calendars or diocesan calendars.
+  The filter can have a value of either __`CalendarSelectFilter.NATIONAL_CALENDARS`__ , __`CalendarSelectFilter.DIOCESAN_CALENDARS`__, or __`CalendarSelectFilter.NONE`__.
+* `allowNull( allowNull = true )`: sets whether the select element should include an empty option as the first option.
+  If this method is not called, the default is false; if it is called without a parameter, the default is true.
+  Otherwise, the method will take a boolean parameter to set whether the select element should include an empty option as the first option.
+  An empty option corresponds to the General Roman Calendar for the API, since no national or diocesan calendar is selected.
+* `after( htmlString )`: allows to insert HTML content after the select element, for example to add a description below the select element.
+  The HTML content must be a string, and the string is sanitized and stripped of any PHP or JavaScript script tags.
+* `linkToNationsSelect( calendarSelectInstance )`: in case the current `CalendarSelect` instance has the `CalendarSelectFilter.DIOCESAN_CALENDARS` filter applied,
+  this method can be used to link the current CalendarSelect instance to a `CalendarSelectFilter.NATIONAL_CALENDARS` filtered CalendarSelect instance,
+  so that the diocese options of the current CalendarSelect instance will be filtered according to the selected nation in the linked CalendarSelect instance.
 
-All of the above stated methods can only be called once on the `CalendarSelect` instance. They are however idempotent, so if called multiple times with the same value no error will be thrown. If however you attempt to call them multiple times with different values, an error will be thrown.
+All of the above stated methods can only be called once on the `CalendarSelect` instance.
+They are however idempotent, so if called multiple times with the same value no error will be thrown.
+If however you attempt to call them multiple times with different values, an error will be thrown.
 
 And as previously stated, the following non chainable methods are available on the `CalendarSelect` instance, and so should be the last method of the chain:
-* `appendTo(elementSelector)`: inserts the select element into the DOM, by passing the CSS selector for the element to which the select element should be appended. This must be a valid CSS selector, and the relative element must exist in the DOM, otherwise an error will be thrown.
+
+* `appendTo(elementSelector)`: inserts the select element into the DOM, by passing the CSS selector for the element to which the select element should be appended.
+  This must be a valid CSS selector, and the relative element must exist in the DOM, otherwise an error will be thrown.
 * `replace(elementSelector)`: similar to the `appendTo()` method, but instead of being appended to the specified element, it will replace the specified element with the select element.
 
 Once either of the two above non chainable methods are called, the `CalendarSelect` instance can no longer be configured using the chainable configuration methods.
 
 The `CalendarSelect` instances expose the following readonly instance properties:
+
 * `_domElement`: the underlying DOM element of the `CalendarSelect` instance
-* `_filter`: the current filter applied to the `CalendarSelect` instance, if any. If none is applied, the value should be __'none'__ (which is the underlying value of `CalendarSelectFilter.NONE`).
+* `_filter`: the current filter applied to the `CalendarSelect` instance, if any.
+  If none is applied, the value should be __'none'__ (which is the underlying value of `CalendarSelectFilter.NONE`).
 
 ### ApiOptions
 
-The `ApiOptions` class is a JavaScript class that generates form controls for the Liturgical Calendar API options. It allows you to easily add an options form to your website, alongside a `CalendarSelect` widget.
+The `ApiOptions` component generates form controls for the Liturgical Calendar API options.
+It allows you to easily add an options form to your website, alongside a `CalendarSelect` widget.
 
 The `ApiOptions` class can be instantiated with a `locale` parameter, which will determine the localization for the UI elements (such as values in the select dropdowns).
 
-The `ApiOptions` class will instantiate nine form controls, four of which are only useful for the General Roman Calendar, while the other four are useful for any calendar, whether General Roman or National or Diocesan. Most applications will only find use for the first four form controls as follows, which are useful for any calendar.
+The `ApiOptions` class will instantiate nine form controls, four of which are only useful for the General Roman Calendar,
+while the other four are useful for any calendar, whether General Roman or National or Diocesan.
+Most applications will only find use for the first four form controls as follows, which are useful for any calendar.
 
 #### Form controls useful for any calendar
+
 * `_yearInput`: a number input for the calendar year
 * `_yearTypeInput`: a select input with options for the type of year to produce, whether liturgical or civil
 * `_localeInput`: a select input with options for the locale to use for the calendar response from the API
 * `_acceptHeaderInput`: a select input with options for the Accept header to use for the calendar response from the API
 
 #### Form controls useful only for the General Roman Calendar
-These four form controls are useful when producing a liturgical calendar for a geographical area, when the national or diocesan data is not yet available in the API.
 
-They allow to tweak parameters that the national or diocesan calendar would otherwise set, such as the date of Epiphany, the date of the Ascension, the date of Corpus Christi, and whether Eternal High Priest is celebrated.
+These four form controls are useful for fine-tuning the General Roman Calendar, when the national or diocesan data is not requested,
+for example to see what the API results would look like for a particular calendar that has not yet been implemented in the API.
+
+They allow to tweak parameters that the national or diocesan calendar would otherwise set,
+such as the date of Epiphany, the date of the Ascension, the date of Corpus Christi, and whether Eternal High Priest is celebrated.
+
 * `_epiphanyInput`: a select input with options for when Epiphany is celebrated
 * `_ascensionInput`: a select input with options for when Ascension is celebrated
 * `_corpusChristiInput`: a select input with options for when Corpus Christi is celebrated
 * `_eternalHighPriestInput`: a select input with options for whether Eternal High Priest is celebrated
 
 #### Path builder form control
+
 A ninth form control is also available, which is useful to assist in building URLs for the API:
+
 * `_calendarPathInput`: a select input with options for the path to use for the API requests
 
 #### Filtering the form controls
-The `ApiOptions` instance can be filtered to output only the form controls that are useful for the General Roman Calendar, or only the form controls that are useful for any calendar. The default filter value is __`ApiOptionsFilter.NONE`__ (which means all possible form controls will be appended). If instead we want to apply a filter to the form controls, we can do so by calling the `filter()` method and passing in a value of either __`ApiOptionsFilter.GENERAL_ROMAN`__ or __`ApiOptionsFilter.ALL_CALENDARS`__.
 
-Applying a filter can be useful if for example you're only interested in dealing with National or Diocesan liturgical calendars, and have no need for the tweakable options that only apply to the General Roman Calendar: in this case you would call the `filter()` method with a value of __`OptionsFilter.ALL_CALENDARS`__.
+The `ApiOptions` instance can be filtered to output only the form controls that are useful for "tweaking" the General Roman Calendar,
+or only the form controls that are useful for any calendar.
+The default filter value is __`ApiOptionsFilter.NONE`__ (which means all possible form controls will be appended).
+If instead we want to apply a filter to the form controls,
+we can do so by calling the `filter()` method and passing in a value of either __`ApiOptionsFilter.GENERAL_ROMAN`__ or __`ApiOptionsFilter.ALL_CALENDARS`__.
 
-If instead you would like to output only the form controls that are useful for the General Roman Calendar but not for other calendars, you would call the `filter()` method with a value of __`ApiOptionsFilter.GENERAL_ROMAN`__.
+Applying a filter can be useful if for example you're only interested in dealing with National or Diocesan liturgical calendars,
+and have no need for the tweakable options that only apply to the General Roman Calendar:
+in this case you would call the `filter()` method with a value of __`OptionsFilter.ALL_CALENDARS`__.
+
+If instead you would like to output only the form controls that are useful for the General Roman Calendar but not for other calendars,
+you would call the `filter()` method with a value of __`ApiOptionsFilter.GENERAL_ROMAN`__.
 
 Example:
+
 ```javascript
 import { ApiOptions, ApiOptionsFilter } from 'liturgical-calendar-js';
 const apiOptions = new ApiOptions( 'en-US' );
 apiOptions.filter(ApiOptionsFilter.ALL_CALENDARS).appendTo( '#calendarOptions');
 ```
 
-There is however one other possible filter, which is __`ApiOptionsFilter.PATH_BUILDER`__, which will only produce the `_calendarPathInput` form control and the `_yearInput` form control. If this filter is set on the `ApiOptions` instance and the form controls are appended to the document, a successive call to the `filter()` method with a value of __`ApiOptionsFilter.ALL_CALENDARS`__ will not include a `_yearInput` since it was already included in the __`ApiOptionsFilter.PATH_BUILDER`__ filter. When the __`ApiOptionsFilter.PATH_BUILDER`__ filter is applied, and then the `ApiOptions` instance is linked to a `CalendarSelect` instance, the current selected value of the `_calendarPathInput` form control will determine the options available in the `CalendarSelect` instance.
+There is however one other possible filter, which is __`ApiOptionsFilter.PATH_BUILDER`__, which will only produce the `_calendarPathInput` form control and the `_yearInput` form control.
+If this filter is set on the `ApiOptions` instance and the form controls are appended to the document,
+a successive call to the `filter()` method with a value of __`ApiOptionsFilter.ALL_CALENDARS`__
+will not include a `_yearInput` since it was already included in the __`ApiOptionsFilter.PATH_BUILDER`__ filter.
+When the __`ApiOptionsFilter.PATH_BUILDER`__ filter is applied, and then the `ApiOptions` instance is linked to a `CalendarSelect` instance,
+the current selected value of the `_calendarPathInput` form control will determine the options available in the `CalendarSelect` instance.
 
 #### Configuring the form controls
-All of the form controls produced by the `ApiOptions` class inherit from a common `Input` class, and can be configured globally to have the same classes or wrapper elements. This can be accomplished with the following static class methods:
+
+All of the form controls produced by the `ApiOptions` class inherit from a common `Input` class, and can be configured globally to have the same classes or wrapper elements.
+This can be accomplished with the following static class methods:
+
 * `Input.setGlobalInputClass(className)`: a space separated string of class names to be assigned globally to each form control element
 * `Input.setGlobalLabelClass(className)`: a space separated string of class names to be assigned globally to each form label element
 * `Input.setGlobalWrapper(element)`: the tag name of the wrapper element that will wrap each form control element, currently only values of __'div'__ and __'td'__ are supported
 * `Input.setGlobalWrapperClass(className)`: a space separated string of class names to be assigned globally to each wrapper element
 
-For this very reason, the `Input` class is also exported by the `@liturgical-calendar/components-js` package's main `dist/index.js`. The `Input` class is not meant to be instantiated, but rather used statically to simplify the global configuration of the form controls produced by the `ApiOptions` class.
+For this very reason, the `Input` class is also exported by the `@liturgical-calendar/components-js` package's main `dist/index.js`.
+The `Input` class is not meant to be instantiated, but rather used statically to simplify the global configuration of the form controls produced by the `ApiOptions` class.
 
 Other than the global configurations, each individual form control can be configured using the following chainable configuration methods on the single form control instances:
+
 * `class( className )`: sets the class or classes to apply to the form control element
 * `id( id )`: sets the id to apply to the form control element (without an initial '#')
 * `name( name )`: sets the name to apply to the form control element (usually the same as the id, not very useful since we probably won't be submitting the form)
@@ -320,12 +413,16 @@ Other than the global configurations, each individual form control can be config
 * `wrapper( tagName )`: configures a wrapper element, which the form control element will be wrapped in. The tag name can have a value of either __'div'__ or __'td'__.
 * `wrapperClass( className )`: sets the class or classes to apply to the wrapper element
 * `disabled( disabled = true )`: sets the `disabled` attribute on the form control element based on the boolean value passed in
-* `data( data )`: the `data` parameter is a map of `key` => `value` pairs that represent the data attributes to be set on the form control element. The `key` is the data attribute name (without the initial `data-`), and the `value` is the data attribute value.
+* `data( data )`: the `data` parameter is a map of `key` => `value` pairs that represent the data attributes to be set on the form control element.
+  The `key` is the data attribute name (without the initial `data-`), and the `value` is the data attribute value.
 * `defaultValue(value)`: sets the default value to apply to the form control element.
 
-Let's say we are using `bootstrap` to theme our UI interface, and we want to style the form controls with `bootstrap` classes. All of the form controls produced by the `ApiOptions` class are <kbd>\<select\></kbd> elements except for the `_yearInput` element which is an <kbd>\<input[type="number"]\></kbd> element. We we might want to apply a class of `form-select` globally to all form controls, but apply a class of `form-control` to the `_yearInput` form control.
+Let's say we are using `bootstrap` to theme our UI interface, and we want to style the form controls with `bootstrap` classes.
+All of the form controls produced by the `ApiOptions` class are <kbd>\<select\></kbd> elements except for the `_yearInput` element which is an <kbd>\<input[type="number"]\></kbd> element.
+We we might want to apply a class of `form-select` globally to all form controls, but apply a class of `form-control` to the `_yearInput` form control.
 
 Example:
+
 ```javascript
 import { ApiOptions, Input } from "@liturgical-calendar/components-js";
 
@@ -344,12 +441,15 @@ ApiClient.init('http://localhost:8000').then((apiClient) => {
 });
 ```
 
-In most cases, we will only be requesting JSON data from the API, so we will not need the `_acceptHeaderInput` form control. The `_acceptHeaderInput` provides a chainable `hide(hide = true)` method which will prevent the form control from being appended to the form.
+In most cases, we will only be requesting JSON data from the API, so we will not need the `_acceptHeaderInput` form control.
+The `_acceptHeaderInput` provides a chainable `hide(hide = true)` method which will prevent the form control from being appended to the form.
 
 #### Dynamically updating the form controls based on selected calendar
+
 We can also set our `ApiOptions` instance to "listen" to a `CalendarSelect` instance. This will allow us to dynamically update the form controls based on the selected calendar.
 
 Example:
+
 ```javascript
 const calendarSelect = new CalendarSelect( 'en-US' );
 const apiOptions = new ApiOptions( 'en-US' );
@@ -358,53 +458,79 @@ apiOptions.linkToCalendarSelect( calendarSelect ).appendTo( '#calendarOptions' )
 ```
 
 Once the `ApiOptions` instance is linked to a `CalendarSelect` instance, the form controls will be dynamically updated based on the selected calendar:
-* The selected calendar's settings will be used to populate the `_epiphanyInput`, `_ascensionInput`, `_corpusChristiInput`, and `_eternalHighPriestInput` select elements, and these will be disabled
+
+* The selected calendar's settings will be used to populate the `_epiphanyInput`, `_ascensionInput`, `_corpusChristiInput`,
+  `_eternalHighPriestInput`, and `_holydaysOfObligationInput` select elements, and these will be disabled
 * The options for the `_localeInput` select element will be filtered according to the selected calendar
 
 > [!NOTE]
 > Currently an `ApiOptions` instance can only to a single unfiltered `CalendarSelect` instance.
-> Linking to dual filtered `CalendarSelect` instances, one that is filtered with National Calendars and another filtered for Diocesan Calendars, is on the roadmap, but not yet fully tested.
+> Linking to dual filtered `CalendarSelect` instances, one that is filtered with National Calendars and another filtered for Diocesan Calendars,
+> is on the roadmap, but not yet fully tested.
 
 ### WebCalendar
 
-The WebCalendar class is a JavaScript class that generates a Liturgical Calendar in an HTML table element.
+The `WebCalendar` component generates a Liturgical Calendar as an HTML table element.
 
-The WebCalendar class instances provide a number of chainable methods to configure the Liturgical Calendar, such as:
+The `WebCalendar` class instances provide a number of chainable methods to configure the Liturgical Calendar, such as:
+
 * `id( id )`: sets the id to apply to the table element (without an initial '#')
 * `class( className )`: sets the class or classes to apply to the table element
-* `firstColumnGrouping( grouping )`: sets the grouping for the first column of the table, can be either `Grouping.BY_MONTH` or `Grouping.BY_LITURGICAL_SEASON` (the `Grouping` enum can be imported from the `@liturgical-calendar/components-js` package)
+* `firstColumnGrouping( grouping )`: sets the grouping for the first column of the table, can be either `Grouping.BY_MONTH` or `Grouping.BY_LITURGICAL_SEASON`
+  (the `Grouping` enum can be imported from the `@liturgical-calendar/components-js` package)
 * `psalterWeekColumn( boolVal=true )`: whether to show the psalter week column as the right hand most column of the table (psalter week values are grouped by default when enabled)
 * `removeHeaderRow( boolVal=true )`: if we want to hide the header row
 * `removeCaption( boolVal=true )`: if we want to hide the table caption
 * `monthHeader( boolVal=true )`: if we want to enable a month header row at the start of each month
-* `seasonColor(ColorAs.CSS_CLASS)`: sets how the color of a liturgical season is applied to the table, whether as a CSS class, an inline style, or a small colored circle (you can import the `ColorAs` enum to assist with these values: `ColorAs.CSS_CLASS`, `ColorAs.BACKGROUND`, `ColorAs.INDICATOR`, `ColorAs.NONE`)
-* `seasonColorColumns(Column.LITURGICAL_SEASON)`: sets which columns should be affected by the `seasonColor` settings. You can import the `Column` enum to assist with these values: `Column.LITURGICAL_SEASON`, `Column.MONTH`, `Column.DATE`, `Column.EVENT_DETAILS`, `Column.GRADE`, `Column.PSALTER_WEEK`, `Column.ALL`, `Column.NONE`. Aside from `Column.ALL` and `Column.NONE`, the other column values are bitfield values, so they can be combined with a bitwise OR operator `|`.
-* `eventColor(ColorAs.INDICATOR)`: sets how the color of the liturgical event is applied to the table (import the `ColorAs` enum to assist with these values: `ColorAs.CSS_CLASS`, `ColorAs.BACKGROUND`, `ColorAs.INDICATOR`, `ColorAs.NONE`)
-* `eventColorColumns(Column.EVENT_DETAILS)`: sets which columns should be affected by the `eventColor` settings. You can import the `Column` enum to assist with these values, see the `seasonColorColumns()` method above for usage of the `Column` enum cases
-* `dateFormat(DateFormat.DAY_ONLY)`: sets how the date should be displayed in the Date column. You can import the `DateFormat` enum to assist with these values: `DateFormat.FULL`, `DateFormat.LONG`, `DateFormat.MEDIUM`, `DateFormat.SHORT`, `DateFormat.DAY_ONLY`. Values of `FULL`, `LONG`, `MEDIUM` and `SHORT` correspond with the values that can be set on the `dateStyle` parameter of an `Intl.DateTimeFormat` instance, whereas `DAY_ONLY` will display only the day of the month and the weekday
-* `columnOrder(ColumnOrder.GRADE_FIRST)`: whether the event details column should come before the liturgical grade column. You can import the `ColumnOrder` enum to assist with these values: `ColumnOrder.GRADE_FIRST`, `ColumnOrder.EVENT_DETAILS_FIRST`.
-* `gradeDisplay(GradeDisplay.ABBREVIATED)`: whether the liturgical grade should be displayed in full or abbreviated form. You can import the `GradeDisplay` enum to assist with these values: `GradeDisplay.FULL`, `GradeDisplay.ABBREVIATED`.
+* `seasonColor(ColorAs.CSS_CLASS)`: sets how the color of a liturgical season is applied to the table, whether as a CSS class, an inline style, or a small colored circle
+  (you can import the `ColorAs` enum to assist with these values: `ColorAs.CSS_CLASS`, `ColorAs.BACKGROUND`, `ColorAs.INDICATOR`, `ColorAs.NONE`)
+* `seasonColorColumns(Column.LITURGICAL_SEASON)`: sets which columns should be affected by the `seasonColor` settings.
+  You can import the `Column` enum to assist with these values: `Column.LITURGICAL_SEASON`, `Column.MONTH`, `Column.DATE`, `Column.EVENT_DETAILS`,
+  `Column.GRADE`, `Column.PSALTER_WEEK`, `Column.ALL`, `Column.NONE`. Aside from `Column.ALL` and `Column.NONE`, the other column values are bitfield values,
+  so they can be combined with a bitwise OR operator `|`.
+* `eventColor(ColorAs.INDICATOR)`: sets how the color of the liturgical event is applied to the table
+  (import the `ColorAs` enum to assist with these values: `ColorAs.CSS_CLASS`, `ColorAs.BACKGROUND`, `ColorAs.INDICATOR`, `ColorAs.NONE`)
+* `eventColorColumns(Column.EVENT_DETAILS)`: sets which columns should be affected by the `eventColor` settings.
+  You can import the `Column` enum to assist with these values, see the `seasonColorColumns()` method above for usage of the `Column` enum cases
+* `dateFormat(DateFormat.DAY_ONLY)`: sets how the date should be displayed in the Date column.
+  You can import the `DateFormat` enum to assist with these values: `DateFormat.FULL`, `DateFormat.LONG`, `DateFormat.MEDIUM`, `DateFormat.SHORT`, `DateFormat.DAY_ONLY`.
+  Values of `FULL`, `LONG`, `MEDIUM` and `SHORT` correspond with the values that can be set on the `dateStyle` parameter of an `Intl.DateTimeFormat` instance,
+  whereas `DAY_ONLY` will display only the day of the month and the weekday
+* `columnOrder(ColumnOrder.GRADE_FIRST)`: whether the event details column should come before the liturgical grade column.
+  You can import the `ColumnOrder` enum to assist with these values: `ColumnOrder.GRADE_FIRST`, `ColumnOrder.EVENT_DETAILS_FIRST`.
+* `gradeDisplay(GradeDisplay.ABBREVIATED)`: whether the liturgical grade should be displayed in full or abbreviated form.
+  You can import the `GradeDisplay` enum to assist with these values: `GradeDisplay.FULL`, `GradeDisplay.ABBREVIATED`.
+* `latinInterface( latinInterface )`: whether the days of the week should be displayed in ecclesiastical Latin or classic Latin, when a Latin locale is requested.
+  You can import the `LatinInterface` enum to assist with these values: `LatinInterface.ECCLESIASTICAL`, `LatinInterface.CIVIL`.
 * `attachTo( elementSelector )`: the selector for the DOM element in which the web calendar will be rendered, every time the calendar is updated
-* `listenTo( apiClient )`: the `WebCalendar` instance will listen to the `calendarFetched` event emitted by the `ApiClient` instance, and update the calendar when the event is triggered. If the `ApiClient` instance is configured to listen to the `CalendarSelect` instance, the `WebCalendar` instance will dynamically update the calendar based on the selected calendar; if it is configured to listen to the `ApiOptions` instance, the `WebCalendar` instance will dynamically update the calendar based on the selected options.
+* `listenTo( apiClient )`: the `WebCalendar` instance will listen to the `calendarFetched` event emitted by the `ApiClient` instance,
+  and update the calendar when the event is triggered. If the `ApiClient` instance is configured to listen to the `CalendarSelect` instance,
+  the `WebCalendar` instance will dynamically update the calendar based on the selected calendar;
+  if it is configured to listen to the `ApiOptions` instance, the `WebCalendar` instance will dynamically update the calendar based on the selected options.
 
 Example:
+
 ```javascript
 const apiClient = new ApiClient( 'en-US' );
 const webCalendar = new WebCalendar();
 webCalendar.listenTo( apiClient ).attachTo( '#litcalWebcalendar' );
 ```
 
-For a full working example of a __Web Calendar component__ listening to an __API Client component__, which in turn is listening to __Calendar Select__ and __API Options__ components, see the `examples/WebCalendar` folder in the current repository.
+For a full working example of a __Web Calendar component__ listening to an __API Client component__,
+which in turn is listening to __Calendar Select__ and __API Options__ components, see the `examples/WebCalendar` folder in the current repository.
 
-This example also demonstrates how to style the calendar events based on liturgical grade. The `WebCalendar` component adds a number of CSS classes to the single table elements, and these classes also reflect the liturgical grade. This allows us to style an event or elements of the event differently based on liturgical grade.
+This example also demonstrates how to style the calendar events based on liturgical grade.
+The `WebCalendar` component adds a number of CSS classes to the single table elements, and these classes also reflect the liturgical grade.
+This allows us to style an event or elements of the event differently based on liturgical grade.
 
 ### LiturgyOfTheDay
 
-The LiturgyOfTheDay class is a JavaScript class that generates a widget for the Liturgy of the Day.
+The `LiturgyOfTheDay` component generates a widget for the Liturgy of the Day.
 
-Instances of the LiturgyOfTheDay component can be instantiated with a locale code, which will determine the localization for the UI elements (title, date string).
+Instances of the `LiturgyOfTheDay` component can be instantiated with a locale code, which will determine the localization for the UI elements (title, date string).
 
 The LiturgyOfTheDay class instances provide a few chainable methods to configure the Liturgy of the Day components, such as:
+
 * `id( id )`: sets the id to apply to the widget element (without an initial '#')
 * `class( className )`: sets the class or classes to apply to the widget DOM element
 * `titleClass( className )`: sets the class or classes to apply to the title DOM element
@@ -416,10 +542,13 @@ The LiturgyOfTheDay class instances provide a few chainable methods to configure
 * `listenTo( apiClient )`: the `LiturgyOfTheDay` instance will listen to the `calendarFetched` event emitted by the `ApiClient` instance, and update the calendar when the event is triggered
 
 The class instance also provides these two non chainable methods:
+
 * `appendTo( elementSelector )`: the selector for the DOM element in which the Liturgy of the Day widget will be rendered
-* `replace( elementSelector )`: similar to the `appendTo()` method, but instead of being appended to the specified element, it will replace the specified element with the Liturgy of the Day widget, similarly to how many jQuery plugins work.
+* `replace( elementSelector )`: similar to the `appendTo()` method, but instead of being appended to the specified element,
+  it will replace the specified element with the Liturgy of the Day widget, similarly to how many jQuery plugins work.
 
 Example:
+
 ```javascript
 import { ApiClient, LiturgyOfTheDay } from 'https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@latest/+esm';
 
@@ -445,25 +574,41 @@ ApiClient.init('http://localhost:8000').then(apiClient => {
 });
 ```
 
-By default a `year_type` of `LITURGICAL` is fetched from the API, though perhaps a `year_type` of `CIVIL` better suits this component so as to produce liturgical events from January 1st to December 31st, otherwise there won't be any results for the current year after _Saturday of the 34th week of Ordinary Time_. This can be achieved by calling the `setYearType( YearType.CIVIL )` method on the `ApiClient` instance before fetching the calendar, i.e.:
+By default a `year_type` of `LITURGICAL` is fetched from the API,
+though perhaps a `year_type` of `CIVIL` better suits this component so as to produce liturgical events from January 1st to December 31st,
+otherwise there won't be any results for the current year after _Saturday of the 34th week of Ordinary Time_.
+This can be achieved by calling the `setYearType( YearType.CIVIL )` method on the `ApiClient` instance before fetching the calendar, i.e.:
+
 ```javascript
 apiClient.setYearType( YearType.CIVIL );
 ```
 
 In case the calendar has already been fetched, it will need to be re-fetched:
+
 ```javascript
 apiClient.setYearType( YearType.CIVIL ).refetchCalendarData();
 ```
 
 > [!TIP]
-> There is one limitation in this simple example: whichever `year_type` is requested from the `ApiClient` instance, whether `LITURGICAL` or `CIVIL`, there will always be a day in which not all events are included:
-> * in the case of `LITURGICAL`, the _Vigil Mass for the First Sunday of Advent_ for the current solar year, which falls on _Saturday of the 34th week of Ordinary Time_, as well as all events including and following the _First Sunday of Advent_ for the current solar year will not be included
+> There is one limitation in this simple example: whichever `year_type` is requested from the `ApiClient` instance, whether `LITURGICAL` or `CIVIL`,
+> there will always be a day in which not all events are included:
+>
+> * in the case of `LITURGICAL`, the _Vigil Mass for the First Sunday of Advent_ for the current solar year, which falls on _Saturday of the 34th week of Ordinary Time_,
+>   as well as all events including and following the _First Sunday of Advent_ for the current solar year will not be included
 > * in the case of `CIVIL`, the _Vigil Mass for Mary, Mother of God_ will not be included on _December 31st_
 >
 > If you would like to see all events for the current year, there are a couple approaches to achieving this:
-> 1. initially set the `year_type` to `CIVIL`, then attach an event handler to the `calendarFetched` event emitted by the `ApiClient` instance to re-fetch the calendar with `year_type` set to `LITURGICAL` and year set to the next year, if the current date is _December 31st_
-> 2. initially leave the default `year_type` of `LITURGICAL`, then attach an event handler to the `calendarFetched` event emitted by the `ApiClient` instance to re-fetch the calendar with `year_type` set to `CIVIL` if the current date is `greater than or equal to` _Saturday of the 34th week of Ordinary Time_ and `less than` _Monday of the First week of Advent_ of the following liturgical year (i.e. the current solar year), but refetch the calendar with `year_type` set to `LITURGICAL` and year set to the next year if the current date is `greater than or equal to` _Monday of the First week of Advent_. For an example on achieving this while avoiding infinite fetch loops, see the [examples/LiturgyOfTheDay](examples/LiturgyOfTheDay/main.js) example in the current repository or the [LiturgyOfTheDayNationalCalendar.stories.js](src/stories/0_Components/LiturgyOfTheDayNationalCalendar.stories.js) or [LiturgyOfTheDayDiocesanCalendar.stories.js](src/stories/0_Components/LiturgyOfTheDayDiocesanCalendar.stories.js) examples in the current repository.
-
+>
+> 1. initially set the `year_type` to `CIVIL`, then attach an event handler to the `calendarFetched` event emitted by the `ApiClient` instance
+>    to re-fetch the calendar with `year_type` set to `LITURGICAL` and year set to the next year, if the current date is _December 31st_
+> 1. initially leave the default `year_type` of `LITURGICAL`, then attach an event handler to the `calendarFetched` event emitted by the `ApiClient` instance
+>    to re-fetch the calendar with `year_type` set to `CIVIL` if the current date is `greater than or equal to` _Saturday of the 34th week of Ordinary Time_
+>    and `less than` _Monday of the First week of Advent_ of the following liturgical year (i.e. the current solar year),
+>    but refetch the calendar with `year_type` set to `LITURGICAL` and year set to the next year
+>    if the current date is `greater than or equal to` _Monday of the First week of Advent_.
+>    For an example on achieving this while avoiding infinite fetch loops, see the [examples/LiturgyOfTheDay](examples/LiturgyOfTheDay/main.js) example,
+>    or the [LiturgyOfTheDayNationalCalendar.stories.js](src/stories/0_Components/LiturgyOfTheDayNationalCalendar.stories.js) story,
+>    or the [LiturgyOfTheDayDiocesanCalendar.stories.js](src/stories/0_Components/LiturgyOfTheDayDiocesanCalendar.stories.js) story.
 
 ### PathBuilder
 
@@ -474,6 +619,7 @@ Besides a text field, a button is also provided with a link to the same API `GET
 A `PathBuilder` component is instantiated by passing in the `ApiOptions` instance and the `CalendarSelect` instance.
 
 Example:
+
 ```javascript
 const apiOptions = new ApiOptions();
 const calendarSelect = new CalendarSelect();

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The easiest way to use ES Modules in the browser is by importing directly from a
 > import { ApiClient, CalendarSelect, ApiOptions, Input, WebCalendar, Grouping, ColorAs, Column, ColumnOrder, DateFormat, GradeDisplay, CalendarSelectFilter } from '@liturgical-calendar/components-js'
 > ```
 >
-> The importmap let's the browser know where to look for the `@liturgical-calendar/components-js` package.
+> The importmap lets the browser know where to look for the `@liturgical-calendar/components-js` package.
 > The importmap must be defined before the script that imports the `@liturgical-calendar/components-js` package.
 > It's recommended to define the importmap in an inline `<script type="importmap">` rather than load it from a separate file,
 > to avoid unnecessary network requests and possible timing conflicts in loading the importmap before any scripts that import the `@liturgical-calendar/components-js` package.
@@ -343,11 +343,12 @@ Most applications will only find use for the first four form controls as follows
 
 #### Form controls useful only for the General Roman Calendar
 
-These four form controls are useful for fine-tuning the General Roman Calendar, when the national or diocesan data is not requested,
+These five form controls are useful for fine-tuning the General Roman Calendar, when the national or diocesan data is not requested,
 for example to see what the API results would look like for a particular calendar that has not yet been implemented in the API.
 
 They allow to tweak parameters that the national or diocesan calendar would otherwise set,
-such as the date of Epiphany, the date of the Ascension, the date of Corpus Christi, and whether Eternal High Priest is celebrated.
+such as the date of Epiphany, the date of the Ascension, the date of Corpus Christi, whether Eternal High Priest is celebrated,
+and which Holy Days of Obligation are observed.
 
 * `_epiphanyInput`: a select input with options for when Epiphany is celebrated
 * `_ascensionInput`: a select input with options for when Ascension is celebrated
@@ -379,7 +380,7 @@ you would call the `filter()` method with a value of __`ApiOptionsFilter.GENERAL
 Example:
 
 ```javascript
-import { ApiOptions, ApiOptionsFilter } from 'liturgical-calendar-js';
+import { ApiOptions, ApiOptionsFilter } from '@liturgical-calendar/components-js';
 const apiOptions = new ApiOptions( 'en-US' );
 apiOptions.filter(ApiOptionsFilter.ALL_CALENDARS).appendTo( '#calendarOptions');
 ```
@@ -629,3 +630,17 @@ pathBuilder.appendTo( '#pathBuilder' );
 ```
 
 For a full working example, see the `examples/PathBuilder` folder in the current repository.
+
+### Enums
+
+* __`Grouping`__ - `BY_MONTH`, `BY_LITURGICAL_SEASON`. Used in the `WebCalendar` component, to specify how to group the liturgical events.
+* __`ColumnOrder`__ - `GRADE_FIRST`, `EVENT_DETAILS_FIRST`. Used in the `WebCalendar` component, to specify the order of the columns.
+* __`Column`__ - `LITURGICAL_SEASON`, `MONTH`, `DATE`, `EVENT_DETAILS`, `GRADE`, `PSALTER_WEEK`, `ALL`, `NONE`.
+  Bitfield values used in the `WebCalendar` component, to specify which columns to display.
+* __`ColorAs`__ - `CSS_CLASS`, `BACKGROUND`, `INDICATOR`, `NONE`. Used in the `WebCalendar` component, to specify how to apply the liturgical color for each event.
+* __`DateFormat`__ - `FULL`, `LONG`, `MEDIUM`, `SHORT`, `DAY_ONLY`. Used in the `WebCalendar` component, to specify how to display the date in the day column.
+* __`GradeDisplay`__ - `FULL`, `ABBREVIATED`. Used in the `WebCalendar` component, to specify how to display the liturgical grade.
+* __`ApiOptionsFilter`__ - `NONE`, `GENERAL_ROMAN`, `ALL_CALENDARS`, `PATH_BUILDER`, `BASE_PATH`, `ALL_PATHS`. Used in the `ApiOptions` class, to specify which form controls to display.
+* __`CalendarSelectFilter`__ - `NONE`, `NATIONAL_CALENDARS`, `DIOCESAN_CALENDARS`. Used in the `CalendarSelect` class, to specify which calendars should be included in the select element.
+* __`YearType`__ - `LITURGICAL` or `CIVIL`. Used in the `ApiClient` class, to specify the type of the year for which to retrieve the calendar.
+* __`LatinInterface`__ - `CIVIL` or `ECCLESIASTICAL`. Used in the `WebCalendar` component, to specify how to display the days of the week in Latin.

--- a/examples/LiturgyOfTheDay/index.html
+++ b/examples/LiturgyOfTheDay/index.html
@@ -24,6 +24,7 @@
         integrity="sha512-1JkMy1LR9bTo3psH+H4SV5bO2dFylgOy+UJhMus1zF4VEFuZVu5lsi4I6iIndE4N9p01z1554ZDcvMSjMaqCBQ=="
         crossorigin="anonymous"
         referrerpolicy="no-referrer"></script>
+    <!-- to import from CDN use https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@latest/+esm -->
     <script type="importmap">
         {
             "imports": {

--- a/examples/LiturgyOfTheDay/main.js
+++ b/examples/LiturgyOfTheDay/main.js
@@ -36,7 +36,7 @@ ApiClient.init('http://localhost:8000').then(apiClient => {
                     const ChristKing = data.litcal.find(event => {
                         return event.event_key === 'ChristKing';
                     });
-                    const ChristKingDate = new Date(ChristKing.date * 1000);
+                    const ChristKingDate = new Date(ChristKing.date);
                     const Saturday34OrdinaryTimeDate = new Date(ChristKingDate.getTime());
                     Saturday34OrdinaryTimeDate.setDate(ChristKingDate.getDate() + 6);
                     const MondayFirstWeekAdventDate = new Date(ChristKingDate.getTime());

--- a/examples/LiturgyOfTheDay/main.js
+++ b/examples/LiturgyOfTheDay/main.js
@@ -1,4 +1,4 @@
-import { ApiClient, LiturgyOfTheDay, YearType} from 'https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@latest/+esm';
+import { ApiClient, LiturgyOfTheDay, YearType} from 'liturgy-components-js';
 
 const now = new Date();
 const dateToday = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0, 0);

--- a/examples/MultipleForms/index.html
+++ b/examples/MultipleForms/index.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
         integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
         crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/virtual-select-plugin@1.1.0/dist/virtual-select.min.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.1/css/all.min.css"
         integrity="sha512-5Hs3dF2AEPkpNAR7UiOHba+lRSJNeM2ECkwxUIxC1Q/FLycGTbNapWXB4tP889k5T5Ju8fs4b1P5z/iB4nMfSQ=="
         crossorigin="anonymous" referrerpolicy="no-referrer" />
@@ -41,6 +42,15 @@
         integrity="sha512-1JkMy1LR9bTo3psH+H4SV5bO2dFylgOy+UJhMus1zF4VEFuZVu5lsi4I6iIndE4N9p01z1554ZDcvMSjMaqCBQ=="
         crossorigin="anonymous"
         referrerpolicy="no-referrer"></script>
+    <script src="https://cdn.jsdelivr.net/npm/virtual-select-plugin@1.1.0/dist/virtual-select.min.js"></script>
+    <!-- to import from CDN use https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@latest/+esm -->
+    <script type="importmap">
+        {
+            "imports": {
+                "liturgy-components-js": "../../src/index.js"
+            }
+        }
+    </script>
     <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/examples/MultipleForms/main.css
+++ b/examples/MultipleForms/main.css
@@ -102,7 +102,7 @@
 }
 
 #LitCalTable td.red {
-    background-color: lightrose;
+    background-color: lightpink;
     color: black;
 }
 

--- a/examples/MultipleForms/main.css
+++ b/examples/MultipleForms/main.css
@@ -102,11 +102,11 @@
 }
 
 #LitCalTable td.red {
-    background-color: lightpink;
+    background-color: lightrose;
     color: black;
 }
 
-#LitCalTable td.pink {
+#LitCalTable td.rose {
     background-color: mistyrose;
     color: black;
 }
@@ -136,4 +136,18 @@
 
 #LitCalMessages td:first-child {
     border-right: 1px groove White;
+}
+
+.vscomp-toggle-button {
+    border-radius: var(--bs-border-radius);
+}
+
+.vscomp-ele[disabled] .vscomp-toggle-button {
+    background-color: var(--bs-secondary-bg);
+}
+
+.vscomp-wrapper.focused .vscomp-toggle-button, .vscomp-wrapper:focus .vscomp-toggle-button {
+    border-color: #86b7fe;
+    outline: 0;
+    box-shadow: 0 0 0 .25rem rgba(13, 110, 253, .25);
 }

--- a/examples/MultipleForms/main.js
+++ b/examples/MultipleForms/main.js
@@ -39,6 +39,50 @@ function buildAndInitVirtualSelectFromNativeSelect(nativeSelect, vsContainerId) 
   });
 }
 
+/**
+ * Wires up a virtual select for the holy days of obligation setting UI.
+ * @param {ApiOptions} apiOptions - instance of ApiOptions
+ * @param {CalendarSelect} calendarSelect - instance of CalendarSelect
+ * @param {string} vsContainerId - id of virtual select container element
+ * @throws {Error} if apiOptions is not an instance of ApiOptions
+ * @throws {Error} if calendarSelect is not an instance of CalendarSelect
+ * @throws {Error} if vsContainerId is not a non-empty string
+ */
+function wireHdobVS( apiOptions, calendarSelect, vsContainerId ) {
+    if (false === (apiOptions instanceof ApiOptions)) {
+        throw new Error('apiOptions must be an instance of ApiOptions');
+    }
+    if (false === (calendarSelect instanceof CalendarSelect)) {
+        throw new Error('calendarSelect must be an instance of CalendarSelect');
+    }
+    if (false === (typeof vsContainerId === 'string' && vsContainerId.length > 0)) {
+        throw new Error('vsContainerId must be a non-empty string');
+    }
+    // 1. Create a new container element for the virtual select
+    const hdobVirtualSelect = document.createElement('div');
+    hdobVirtualSelect.id = vsContainerId;
+    // 2. Insert it right after the original native select
+    apiOptions._holydaysOfObligationInput._domElement.parentNode.insertBefore( hdobVirtualSelect, apiOptions._holydaysOfObligationInput._domElement.nextSibling );
+    // 3. Build and initialize the virtual select from the native select
+    buildAndInitVirtualSelectFromNativeSelect( apiOptions._holydaysOfObligationInput._domElement, vsContainerId );
+    if (calendarSelect._domElement.value === '') {
+        hdobVirtualSelect.enable();
+    } else {
+        hdobVirtualSelect.disable();
+    }
+    // 4. Listen to changes on the calendar select to rebuild and enable/disable the virtual select
+    calendarSelect._domElement.addEventListener('change', (ev) => {
+        //console.log('calendar changed to:', ev.target.value);
+        hdobVirtualSelect.destroy();
+        buildAndInitVirtualSelectFromNativeSelect( apiOptions._holydaysOfObligationInput._domElement, vsContainerId );
+        if (ev.target.value === '') {
+            hdobVirtualSelect.enable();
+        } else {
+            hdobVirtualSelect.disable();
+        }
+    });
+}
+
 ApiClient.init('http://localhost:8000').then(apiClient => {
     if (false === apiClient) {
         alert('Error initializing the Liturgical Calendar API Client');
@@ -139,30 +183,7 @@ ApiClient.init('http://localhost:8000').then(apiClient => {
 
         apiOptionsEng.linkToCalendarSelect( liturgicalCalendarSelectEng ).appendTo( '#calendarOptionsEnglish' )
 
-        // 1. Create a new container element for the virtual select
-        const hdobVirtualSelectEng = document.createElement('div');
-        hdobVirtualSelectEng.id = 'hdob-virtual-select-eng';
-        // 2. Insert it right after the original native select
-        apiOptionsEng._holydaysOfObligationInput._domElement.parentNode.insertBefore( hdobVirtualSelectEng, apiOptionsEng._holydaysOfObligationInput._domElement.nextSibling );
-        // 3. Build and initialize the virtual select from the native select
-        buildAndInitVirtualSelectFromNativeSelect( apiOptionsEng._holydaysOfObligationInput._domElement, 'hdob-virtual-select-eng' );
-        if (liturgicalCalendarSelectEng._domElement.value === '') {
-            hdobVirtualSelectEng.enable();
-        } else {
-            hdobVirtualSelectEng.disable();
-        }
-        // 4. Listen to changes on the calendar select to rebuild and enable/disable the virtual select
-        liturgicalCalendarSelectEng._domElement.addEventListener('change', (ev) => {
-            console.log('calendar changed to:', ev.target.value);
-            const vsElement = document.querySelector('#hdob-virtual-select-eng');
-            vsElement.destroy();
-            buildAndInitVirtualSelectFromNativeSelect( apiOptionsEng._holydaysOfObligationInput._domElement, 'hdob-virtual-select-eng' );
-            if (ev.target.value === '') {
-                vsElement.enable();
-            } else {
-                vsElement.disable();
-            }
-        });
+        wireHdobVS(apiOptionsEng, liturgicalCalendarSelectEng, 'hdob-virtual-select-eng');
 
         /**
          * Spanish
@@ -178,30 +199,7 @@ ApiClient.init('http://localhost:8000').then(apiClient => {
 
         apiOptionsEsp.linkToCalendarSelect( liturgicalCalendarSelectEsp ).appendTo( '#calendarOptionsSpanish' );
 
-        // 1. Create a new container element for the virtual select
-        const hdobVirtualSelectEsp = document.createElement('div');
-        hdobVirtualSelectEsp.id = 'hdob-virtual-select-esp';
-        // 2. Insert it right after the original native select
-        apiOptionsEsp._holydaysOfObligationInput._domElement.parentNode.insertBefore( hdobVirtualSelectEsp, apiOptionsEsp._holydaysOfObligationInput._domElement.nextSibling );
-        // 3. Build and initialize the virtual select from the native select
-        buildAndInitVirtualSelectFromNativeSelect( apiOptionsEsp._holydaysOfObligationInput._domElement, 'hdob-virtual-select-esp' );
-        if (liturgicalCalendarSelectEsp._domElement.value === '') {
-            hdobVirtualSelectEsp.enable();
-        } else {
-            hdobVirtualSelectEsp.disable();
-        }
-        // 4. Listen to changes on the calendar select to rebuild and enable/disable the virtual select
-        liturgicalCalendarSelectEsp._domElement.addEventListener('change', (ev) => {
-            console.log('calendar changed to:', ev.target.value);
-            const vsElement = document.querySelector('#hdob-virtual-select-esp');
-            vsElement.destroy();
-            buildAndInitVirtualSelectFromNativeSelect( apiOptionsEsp._holydaysOfObligationInput._domElement, 'hdob-virtual-select-esp' );
-            if (ev.target.value === '') {
-                vsElement.enable();
-            } else {
-                vsElement.disable();
-            }
-        });
+        wireHdobVS(apiOptionsEsp, liturgicalCalendarSelectEsp, 'hdob-virtual-select-esp');
 
 
         /**
@@ -218,30 +216,7 @@ ApiClient.init('http://localhost:8000').then(apiClient => {
 
         apiOptionsIta.linkToCalendarSelect( liturgicalCalendarSelectIta ).appendTo( '#calendarOptionsItalian' );
 
-        // 1. Create a new container element for the virtual select
-        const hdobVirtualSelectIta = document.createElement('div');
-        hdobVirtualSelectIta.id = 'hdob-virtual-select-ita';
-        // 2. Insert it right after the original native select
-        apiOptionsIta._holydaysOfObligationInput._domElement.parentNode.insertBefore( hdobVirtualSelectIta, apiOptionsIta._holydaysOfObligationInput._domElement.nextSibling );
-        // 3. Build and initialize the virtual select from the native select
-        buildAndInitVirtualSelectFromNativeSelect( apiOptionsIta._holydaysOfObligationInput._domElement, 'hdob-virtual-select-ita' );
-        if (liturgicalCalendarSelectIta._domElement.value === '') {
-            hdobVirtualSelectIta.enable();
-        } else {
-            hdobVirtualSelectIta.disable();
-        }
-        // 4. Listen to changes on the calendar select to rebuild and enable/disable the virtual select
-        liturgicalCalendarSelectIta._domElement.addEventListener('change', (ev) => {
-            console.log('calendar changed to:', ev.target.value);
-            const vsElement = document.querySelector('#hdob-virtual-select-ita');
-            vsElement.destroy();
-            buildAndInitVirtualSelectFromNativeSelect( apiOptionsIta._holydaysOfObligationInput._domElement, 'hdob-virtual-select-ita' );
-            if (ev.target.value === '') {
-                vsElement.enable();
-            } else {
-                vsElement.disable();
-            }
-        });
+        wireHdobVS(apiOptionsIta, liturgicalCalendarSelectIta, 'hdob-virtual-select-ita');
 
 
         /**
@@ -258,30 +233,7 @@ ApiClient.init('http://localhost:8000').then(apiClient => {
 
         apiOptionsDeu.linkToCalendarSelect( liturgicalCalendarSelectDeu ).appendTo( '#calendarOptionsGerman' );
 
-        // 1. Create a new container element for the virtual select
-        const hdobVirtualSelectDeu = document.createElement('div');
-        hdobVirtualSelectDeu.id = 'hdob-virtual-select-deu';
-        // 2. Insert it right after the original native select
-        apiOptionsDeu._holydaysOfObligationInput._domElement.parentNode.insertBefore( hdobVirtualSelectDeu, apiOptionsDeu._holydaysOfObligationInput._domElement.nextSibling );
-        // 3. Build and initialize the virtual select from the native select
-        buildAndInitVirtualSelectFromNativeSelect( apiOptionsDeu._holydaysOfObligationInput._domElement, 'hdob-virtual-select-deu' );
-        if (liturgicalCalendarSelectDeu._domElement.value === '') {
-            hdobVirtualSelectDeu.enable();
-        } else {
-            hdobVirtualSelectDeu.disable();
-        }
-        // 4. Listen to changes on the calendar select to rebuild and enable/disable the virtual select
-        liturgicalCalendarSelectDeu._domElement.addEventListener('change', (ev) => {
-            console.log('calendar changed to:', ev.target.value);
-            const vsElement = document.querySelector('#hdob-virtual-select-deu');
-            vsElement.destroy();
-            buildAndInitVirtualSelectFromNativeSelect( apiOptionsDeu._holydaysOfObligationInput._domElement, 'hdob-virtual-select-deu' );
-            if (ev.target.value === '') {
-                vsElement.enable();
-            } else {
-                vsElement.disable();
-            }
-        });
+        wireHdobVS(apiOptionsDeu, liturgicalCalendarSelectDeu, 'hdob-virtual-select-deu');
 
         // Fetch initial webcalendar
         apiClient.fetchNationalCalendar( 'VA' );

--- a/examples/MultipleForms/main.js
+++ b/examples/MultipleForms/main.js
@@ -1,9 +1,43 @@
-import { ApiClient, CalendarSelect, ApiOptions, Input, WebCalendar, Grouping, ColorAs, Column, ColumnOrder, DateFormat, GradeDisplay, CalendarSelectFilter } from 'https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@latest/+esm';
+import { ApiClient, CalendarSelect, ApiOptions, Input, WebCalendar, Grouping, ColorAs, Column, ColumnOrder, DateFormat, GradeDisplay, CalendarSelectFilter } from 'liturgy-components-js';
 
 Input.setGlobalInputClass('form-select');
 Input.setGlobalLabelClass('form-label d-block mb-1');
 Input.setGlobalWrapper('div');
 Input.setGlobalWrapperClass('form-group col col-md-3');
+
+function buildVirtualSelectOptions( selectElement ) {
+    return Array.from(selectElement.options).map(opt => ({
+        label: opt.textContent,
+        value: opt.value,
+        selected: opt.selected
+    }));
+}
+
+function buildAndInitVirtualSelectFromNativeSelect(nativeSelect, vsContainerId) {
+  // 1) build options and selected values
+  const opts = buildVirtualSelectOptions(nativeSelect);
+  const selectedValues = opts.filter(o => o.selected).map(o => o.value);
+
+  // 2) init VirtualSelect on the div container
+  VirtualSelect.init({
+    ele: `#${vsContainerId}`,
+    showValueAsTags: true,
+    //additionalToggleButtonClasses: "btn",
+    additionalDropboxContainerClasses: "dropdown-menu",
+    multiple: true,
+    search: false,
+    options: opts,
+    selectedValue: selectedValues,
+    onChange: function(value) {
+        // value is an array in multiple mode
+        // sync back to the native select
+        Array.from(nativeSelect.options).forEach(opt => {
+            opt.selected = value.includes(opt.value);
+        });
+        nativeSelect.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+  });
+}
 
 ApiClient.init('http://localhost:8000').then(apiClient => {
     if (false === apiClient) {
@@ -31,8 +65,30 @@ ApiClient.init('http://localhost:8000').then(apiClient => {
         apiOptionsEsp._yearInput.class( 'form-control' );
         apiOptionsIta._yearInput.class( 'form-control' );
         apiOptionsDeu._yearInput.class( 'form-control' );
+
+        apiOptionsEng._ascensionInput.wrapperClass( 'form-group col col-md-2' );
+        apiOptionsEng._corpusChristiInput.wrapperClass( 'form-group col col-md-2' );
+        apiOptionsEng._eternalHighPriestInput.wrapperClass( 'form-group col col-md-2' );
+        apiOptionsEng._holydaysOfObligationInput.class('d-none');
+
+        apiOptionsEsp._ascensionInput.wrapperClass( 'form-group col col-md-2' );
+        apiOptionsEsp._corpusChristiInput.wrapperClass( 'form-group col col-md-2' );
+        apiOptionsEsp._eternalHighPriestInput.wrapperClass( 'form-group col col-md-2' );
+        apiOptionsEsp._holydaysOfObligationInput.class('d-none');
+
+        apiOptionsIta._ascensionInput.wrapperClass( 'form-group col col-md-2' );
+        apiOptionsIta._corpusChristiInput.wrapperClass( 'form-group col col-md-2' );
+        apiOptionsIta._eternalHighPriestInput.wrapperClass( 'form-group col col-md-2' );
+        apiOptionsIta._holydaysOfObligationInput.class('d-none');
+
+        apiOptionsDeu._ascensionInput.wrapperClass( 'form-group col col-md-2' );
+        apiOptionsDeu._corpusChristiInput.wrapperClass( 'form-group col col-md-2' );
+        apiOptionsDeu._eternalHighPriestInput.wrapperClass( 'form-group col col-md-2' );
+        apiOptionsDeu._holydaysOfObligationInput.class('d-none');
+
         apiClient.listenTo( liturgicalCalendarSelectEng );
         apiClient.listenTo( apiOptionsEng );
+
         const webCalendar = new WebCalendar();
         webCalendar.id('LitCalTable')
         .firstColumnGrouping(Grouping.BY_LITURGICAL_SEASON)
@@ -83,6 +139,31 @@ ApiClient.init('http://localhost:8000').then(apiClient => {
 
         apiOptionsEng.linkToCalendarSelect( liturgicalCalendarSelectEng ).appendTo( '#calendarOptionsEnglish' )
 
+        // 1. Create a new container element for the virtual select
+        const hdobVirtualSelectEng = document.createElement('div');
+        hdobVirtualSelectEng.id = 'hdob-virtual-select-eng';
+        // 2. Insert it right after the original native select
+        apiOptionsEng._holydaysOfObligationInput._domElement.parentNode.insertBefore( hdobVirtualSelectEng, apiOptionsEng._holydaysOfObligationInput._domElement.nextSibling );
+        // 3. Build and initialize the virtual select from the native select
+        buildAndInitVirtualSelectFromNativeSelect( apiOptionsEng._holydaysOfObligationInput._domElement, 'hdob-virtual-select-eng' );
+        if (liturgicalCalendarSelectEng._domElement.value === '') {
+            hdobVirtualSelectEng.enable();
+        } else {
+            hdobVirtualSelectEng.disable();
+        }
+        // 4. Listen to changes on the calendar select to rebuild and enable/disable the virtual select
+        liturgicalCalendarSelectEng._domElement.addEventListener('change', (ev) => {
+            console.log('calendar changed to:', ev.target.value);
+            const vsElement = document.querySelector('#hdob-virtual-select-eng');
+            vsElement.destroy();
+            buildAndInitVirtualSelectFromNativeSelect( apiOptionsEng._holydaysOfObligationInput._domElement, 'hdob-virtual-select-eng' );
+            if (ev.target.value === '') {
+                vsElement.enable();
+            } else {
+                vsElement.disable();
+            }
+        });
+
         /**
          * Spanish
          */
@@ -92,10 +173,36 @@ ApiClient.init('http://localhost:8000').then(apiClient => {
             text: 'Selecciona calendario'
         }).wrapper({
             class: 'form-group col col-md-3',
-            id: 'liturgicalCalendarSelectEngNationsWrapper'
+            id: 'liturgicalCalendarSelectEspNationsWrapper'
         }).id('liturgicalCalendarSelectEsp').class('form-select').allowNull().appendTo( '#calendarOptionsSpanish');
 
         apiOptionsEsp.linkToCalendarSelect( liturgicalCalendarSelectEsp ).appendTo( '#calendarOptionsSpanish' );
+
+        // 1. Create a new container element for the virtual select
+        const hdobVirtualSelectEsp = document.createElement('div');
+        hdobVirtualSelectEsp.id = 'hdob-virtual-select-esp';
+        // 2. Insert it right after the original native select
+        apiOptionsEsp._holydaysOfObligationInput._domElement.parentNode.insertBefore( hdobVirtualSelectEsp, apiOptionsEsp._holydaysOfObligationInput._domElement.nextSibling );
+        // 3. Build and initialize the virtual select from the native select
+        buildAndInitVirtualSelectFromNativeSelect( apiOptionsEsp._holydaysOfObligationInput._domElement, 'hdob-virtual-select-esp' );
+        if (liturgicalCalendarSelectEsp._domElement.value === '') {
+            hdobVirtualSelectEsp.enable();
+        } else {
+            hdobVirtualSelectEsp.disable();
+        }
+        // 4. Listen to changes on the calendar select to rebuild and enable/disable the virtual select
+        liturgicalCalendarSelectEsp._domElement.addEventListener('change', (ev) => {
+            console.log('calendar changed to:', ev.target.value);
+            const vsElement = document.querySelector('#hdob-virtual-select-esp');
+            vsElement.destroy();
+            buildAndInitVirtualSelectFromNativeSelect( apiOptionsEsp._holydaysOfObligationInput._domElement, 'hdob-virtual-select-esp' );
+            if (ev.target.value === '') {
+                vsElement.enable();
+            } else {
+                vsElement.disable();
+            }
+        });
+
 
         /**
          * Italian
@@ -106,10 +213,36 @@ ApiClient.init('http://localhost:8000').then(apiClient => {
             text: 'Seleziona calendario'
         }).wrapper({
             class: 'form-group col col-md-3',
-            id: 'liturgicalCalendarSelectEngNationsWrapper'
+            id: 'liturgicalCalendarSelectItaNationsWrapper'
         }).id('liturgicalCalendarSelectIta').class('form-select').appendTo( '#calendarOptionsItalian');
 
         apiOptionsIta.linkToCalendarSelect( liturgicalCalendarSelectIta ).appendTo( '#calendarOptionsItalian' );
+
+        // 1. Create a new container element for the virtual select
+        const hdobVirtualSelectIta = document.createElement('div');
+        hdobVirtualSelectIta.id = 'hdob-virtual-select-ita';
+        // 2. Insert it right after the original native select
+        apiOptionsIta._holydaysOfObligationInput._domElement.parentNode.insertBefore( hdobVirtualSelectIta, apiOptionsIta._holydaysOfObligationInput._domElement.nextSibling );
+        // 3. Build and initialize the virtual select from the native select
+        buildAndInitVirtualSelectFromNativeSelect( apiOptionsIta._holydaysOfObligationInput._domElement, 'hdob-virtual-select-ita' );
+        if (liturgicalCalendarSelectIta._domElement.value === '') {
+            hdobVirtualSelectIta.enable();
+        } else {
+            hdobVirtualSelectIta.disable();
+        }
+        // 4. Listen to changes on the calendar select to rebuild and enable/disable the virtual select
+        liturgicalCalendarSelectIta._domElement.addEventListener('change', (ev) => {
+            console.log('calendar changed to:', ev.target.value);
+            const vsElement = document.querySelector('#hdob-virtual-select-ita');
+            vsElement.destroy();
+            buildAndInitVirtualSelectFromNativeSelect( apiOptionsIta._holydaysOfObligationInput._domElement, 'hdob-virtual-select-ita' );
+            if (ev.target.value === '') {
+                vsElement.enable();
+            } else {
+                vsElement.disable();
+            }
+        });
+
 
         /**
          * German
@@ -120,9 +253,37 @@ ApiClient.init('http://localhost:8000').then(apiClient => {
             text: 'Kalender ausw&auml;hlen'
         }).wrapper({
             class: 'form-group col col-md-3',
-            id: 'liturgicalCalendarSelectEngNationsWrapper'
+            id: 'liturgicalCalendarSelectDeuNationsWrapper'
         }).id('liturgicalCalendarSelectDeu').class('form-select').appendTo( '#calendarOptionsGerman');
 
         apiOptionsDeu.linkToCalendarSelect( liturgicalCalendarSelectDeu ).appendTo( '#calendarOptionsGerman' );
+
+        // 1. Create a new container element for the virtual select
+        const hdobVirtualSelectDeu = document.createElement('div');
+        hdobVirtualSelectDeu.id = 'hdob-virtual-select-deu';
+        // 2. Insert it right after the original native select
+        apiOptionsDeu._holydaysOfObligationInput._domElement.parentNode.insertBefore( hdobVirtualSelectDeu, apiOptionsDeu._holydaysOfObligationInput._domElement.nextSibling );
+        // 3. Build and initialize the virtual select from the native select
+        buildAndInitVirtualSelectFromNativeSelect( apiOptionsDeu._holydaysOfObligationInput._domElement, 'hdob-virtual-select-deu' );
+        if (liturgicalCalendarSelectDeu._domElement.value === '') {
+            hdobVirtualSelectDeu.enable();
+        } else {
+            hdobVirtualSelectDeu.disable();
+        }
+        // 4. Listen to changes on the calendar select to rebuild and enable/disable the virtual select
+        liturgicalCalendarSelectDeu._domElement.addEventListener('change', (ev) => {
+            console.log('calendar changed to:', ev.target.value);
+            const vsElement = document.querySelector('#hdob-virtual-select-deu');
+            vsElement.destroy();
+            buildAndInitVirtualSelectFromNativeSelect( apiOptionsDeu._holydaysOfObligationInput._domElement, 'hdob-virtual-select-deu' );
+            if (ev.target.value === '') {
+                vsElement.enable();
+            } else {
+                vsElement.disable();
+            }
+        });
+
+        // Fetch initial webcalendar
+        apiClient.fetchNationalCalendar( 'VA' );
     }
 });

--- a/examples/PathBuilder/index.html
+++ b/examples/PathBuilder/index.html
@@ -8,21 +8,23 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
         integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
         crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/virtual-select-plugin@1.1.0/dist/virtual-select.min.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.1/css/all.min.css"
         integrity="sha512-5Hs3dF2AEPkpNAR7UiOHba+lRSJNeM2ECkwxUIxC1Q/FLycGTbNapWXB4tP889k5T5Ju8fs4b1P5z/iB4nMfSQ=="
         crossorigin="anonymous"
         referrerpolicy="no-referrer" />
+    <link rel="stylesheet" type="text/css" media="screen" href="main.css" />
 </head>
 <body class="p-4">
     <h1>Liturgical Calendar Components JS: Path builder example</h1>
     <div class="row mb-2" id="pathBuilder">
         <h5 class="fw-bold">Path builder</h5>
     </div>
-    <div class="row mb-2" id="requestParametersBasePath">
-        <h5 class="fw-bold">Request parameters available on the base <b><code>/calendar</code></b> path</h5>
-    </div>
     <div class="row mb-2" id="requestParametersAllPaths">
         <h5 class="fw-bold">Request parameters available on all <b><code>/calendar/*</code></b> paths</h5>
+    </div>
+    <div class="row mb-2" id="requestParametersBasePath">
+        <h5 class="fw-bold">Request parameters available on the base <b><code>/calendar</code></b> path</h5>
     </div>
     <div id="pathBuilderResult">
     </div>
@@ -33,6 +35,7 @@
         integrity="sha512-1JkMy1LR9bTo3psH+H4SV5bO2dFylgOy+UJhMus1zF4VEFuZVu5lsi4I6iIndE4N9p01z1554ZDcvMSjMaqCBQ=="
         crossorigin="anonymous"
         referrerpolicy="no-referrer"></script>
+    <script src="https://cdn.jsdelivr.net/npm/virtual-select-plugin@1.1.0/dist/virtual-select.min.js"></script>
     <script type="importmap">
         {
             "imports": {

--- a/examples/PathBuilder/main.css
+++ b/examples/PathBuilder/main.css
@@ -1,0 +1,13 @@
+.vscomp-toggle-button {
+    border-radius: var(--bs-border-radius);
+}
+
+.vscomp-ele[disabled] .vscomp-toggle-button {
+    background-color: var(--bs-secondary-bg);
+}
+
+.vscomp-wrapper.focused .vscomp-toggle-button, .vscomp-wrapper:focus .vscomp-toggle-button {
+    border-color: #86b7fe;
+    outline: 0;
+    box-shadow: 0 0 0 .25rem rgba(13, 110, 253, .25);
+}

--- a/examples/PathBuilder/main.js
+++ b/examples/PathBuilder/main.js
@@ -39,6 +39,50 @@ function buildAndInitVirtualSelectFromNativeSelect(nativeSelect, vsContainerId) 
   });
 }
 
+/**
+ * Wires up a virtual select for the holy days of obligation setting UI.
+ * @param {ApiOptions} apiOptions - instance of ApiOptions
+ * @param {CalendarSelect} calendarSelect - instance of CalendarSelect
+ * @param {string} vsContainerId - id of virtual select container element
+ * @throws {Error} if apiOptions is not an instance of ApiOptions
+ * @throws {Error} if calendarSelect is not an instance of CalendarSelect
+ * @throws {Error} if vsContainerId is not a non-empty string
+ */
+function wireHdobVS( apiOptions, calendarSelect, vsContainerId ) {
+    if (false === (apiOptions instanceof ApiOptions)) {
+        throw new Error('apiOptions must be an instance of ApiOptions');
+    }
+    if (false === (calendarSelect instanceof CalendarSelect)) {
+        throw new Error('calendarSelect must be an instance of CalendarSelect');
+    }
+    if (false === (typeof vsContainerId === 'string' && vsContainerId.length > 0)) {
+        throw new Error('vsContainerId must be a non-empty string');
+    }
+    // 1. Create a new container element for the virtual select
+    const hdobVirtualSelect = document.createElement('div');
+    hdobVirtualSelect.id = vsContainerId;
+    // 2. Insert it right after the original native select
+    apiOptions._holydaysOfObligationInput._domElement.parentNode.insertBefore( hdobVirtualSelect, apiOptions._holydaysOfObligationInput._domElement.nextSibling );
+    // 3. Build and initialize the virtual select from the native select
+    buildAndInitVirtualSelectFromNativeSelect( apiOptions._holydaysOfObligationInput._domElement, vsContainerId );
+    if (calendarSelect._domElement.value === '') {
+        hdobVirtualSelect.enable();
+    } else {
+        hdobVirtualSelect.disable();
+    }
+    // 4. Listen to changes on the calendar select to rebuild and enable/disable the virtual select
+    calendarSelect._domElement.addEventListener('change', (ev) => {
+        //console.log('calendar changed to:', ev.target.value);
+        hdobVirtualSelect.destroy();
+        buildAndInitVirtualSelectFromNativeSelect( apiOptions._holydaysOfObligationInput._domElement, vsContainerId );
+        if (ev.target.value === '') {
+            hdobVirtualSelect.enable();
+        } else {
+            hdobVirtualSelect.disable();
+        }
+    });
+}
+
 ApiClient.init('http://localhost:8000').then(apiClient => {
     if (false === apiClient || false === apiClient instanceof ApiClient) {
         alert('Error initializing the Liturgical Calendar API Client');
@@ -68,31 +112,7 @@ ApiClient.init('http://localhost:8000').then(apiClient => {
         apiOptions.filter( ApiOptionsFilter.ALL_PATHS ).appendTo('#requestParametersAllPaths');
         apiOptions.filter( ApiOptionsFilter.BASE_PATH ).appendTo('#requestParametersBasePath');
 
-        // 1. Create a new container element for the virtual select
-        const hdobVirtualSelect = document.createElement('div');
-        hdobVirtualSelect.id = 'hdob-virtual-select';
-        // 2. Insert it right after the original native select
-        apiOptions._holydaysOfObligationInput._domElement.parentNode.insertBefore( hdobVirtualSelect, apiOptions._holydaysOfObligationInput._domElement.nextSibling );
-        // 3. Build and initialize the virtual select from the native select
-        buildAndInitVirtualSelectFromNativeSelect( apiOptions._holydaysOfObligationInput._domElement, 'hdob-virtual-select' );
-        apiOptions.linkToCalendarSelect( calendarSelect );
-        if (calendarSelect._domElement.value === '') {
-            hdobVirtualSelect.enable();
-        } else {
-            hdobVirtualSelect.disable();
-        }
-        // 4. Listen to changes on the calendar select to update the virtual select accordingly
-        calendarSelect._domElement.addEventListener('change', (ev) => {
-            console.log('calendar changed to:', ev.target.value);
-            const vsElement = document.querySelector('#hdob-virtual-select');
-            vsElement.destroy();
-            buildAndInitVirtualSelectFromNativeSelect( apiOptions._holydaysOfObligationInput._domElement, 'hdob-virtual-select' );
-            if (ev.target.value === '') {
-                vsElement.enable();
-            } else {
-                vsElement.disable();
-            }
-        });
+        wireHdobVS( apiOptions, calendarSelect, 'hdob-virtual-select' );
 
         const pathBuilder = new PathBuilder(apiOptions, calendarSelect)
             .class('row align-items-center ps-2')

--- a/examples/PathBuilder/main.js
+++ b/examples/PathBuilder/main.js
@@ -5,15 +5,52 @@ Input.setGlobalLabelClass('form-label mb-1');
 Input.setGlobalWrapper('div');
 Input.setGlobalWrapperClass('form-group col col-md-3');
 
+function buildVirtualSelectOptions( selectElement ) {
+    return Array.from(selectElement.options).map(opt => ({
+        label: opt.textContent,
+        value: opt.value,
+        selected: opt.selected
+    }));
+}
+
+function buildAndInitVirtualSelectFromNativeSelect(nativeSelect, vsContainerId) {
+  // 1) build options and selected values
+  const opts = buildVirtualSelectOptions(nativeSelect);
+  const selectedValues = opts.filter(o => o.selected).map(o => o.value);
+
+  // 2) init VirtualSelect on the div container
+  VirtualSelect.init({
+    ele: `#${vsContainerId}`,
+    showValueAsTags: true,
+    //additionalToggleButtonClasses: "btn",
+    additionalDropboxContainerClasses: "dropdown-menu",
+    multiple: true,
+    search: false,
+    options: opts,
+    selectedValue: selectedValues,
+    onChange: function(value) {
+        // value is an array in multiple mode
+        // sync back to the native select
+        Array.from(nativeSelect.options).forEach(opt => {
+            opt.selected = value.includes(opt.value);
+        });
+        nativeSelect.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+  });
+}
 
 ApiClient.init('http://localhost:8000').then(apiClient => {
     if (false === apiClient || false === apiClient instanceof ApiClient) {
         alert('Error initializing the Liturgical Calendar API Client');
     } else {
-        const apiOptions = (new ApiOptions( 'en-US' ));
+        const apiOptions = new ApiOptions( 'en-US' );
         apiOptions._localeInput.defaultValue( 'la' );
         apiOptions._acceptHeaderInput.hide();
         apiOptions._yearInput.class( 'form-control' );
+        apiOptions._ascensionInput.wrapperClass( 'form-group col col-md-2' );
+        apiOptions._corpusChristiInput.wrapperClass( 'form-group col col-md-2' );
+        apiOptions._eternalHighPriestInput.wrapperClass( 'form-group col col-md-2' );
+        apiOptions._holydaysOfObligationInput.class('d-none');
         apiOptions.filter( ApiOptionsFilter.PATH_BUILDER ).appendTo('#pathBuilder');
 
         const calendarSelect = (new CalendarSelect( 'en-US' )).allowNull();
@@ -25,16 +62,42 @@ ApiClient.init('http://localhost:8000').then(apiClient => {
             class: 'form-group col col-md-3',
             id: 'calendarSelectWrapper'
         }).id('calendarSelect')
-        .class('form-select')
+        .class('form-control select-input')
         .insertAfter( apiOptions._calendarPathInput );
 
-        apiOptions.filter( ApiOptionsFilter.BASE_PATH ).appendTo('#requestParametersBasePath');
         apiOptions.filter( ApiOptionsFilter.ALL_PATHS ).appendTo('#requestParametersAllPaths');
+        apiOptions.filter( ApiOptionsFilter.BASE_PATH ).appendTo('#requestParametersBasePath');
+
+        // 1. Create a new container element for the virtual select
+        const hdobVirtualSelect = document.createElement('div');
+        hdobVirtualSelect.id = 'hdob-virtual-select';
+        // 2. Insert it right after the original native select
+        apiOptions._holydaysOfObligationInput._domElement.parentNode.insertBefore( hdobVirtualSelect, apiOptions._holydaysOfObligationInput._domElement.nextSibling );
+        // 3. Build and initialize the virtual select from the native select
+        buildAndInitVirtualSelectFromNativeSelect( apiOptions._holydaysOfObligationInput._domElement, 'hdob-virtual-select' );
         apiOptions.linkToCalendarSelect( calendarSelect );
+        if (calendarSelect._domElement.value === '') {
+            hdobVirtualSelect.enable();
+        } else {
+            hdobVirtualSelect.disable();
+        }
+        // 4. Listen to changes on the calendar select to update the virtual select accordingly
+        calendarSelect._domElement.addEventListener('change', (ev) => {
+            console.log('calendar changed to:', ev.target.value);
+            const vsElement = document.querySelector('#hdob-virtual-select');
+            vsElement.destroy();
+            buildAndInitVirtualSelectFromNativeSelect( apiOptions._holydaysOfObligationInput._domElement, 'hdob-virtual-select' );
+            if (ev.target.value === '') {
+                vsElement.enable();
+            } else {
+                vsElement.disable();
+            }
+        });
 
         const pathBuilder = new PathBuilder(apiOptions, calendarSelect)
             .class('row align-items-center ps-2')
-            .pathWrapperClass('col-sm-8 border border-secondary rounded bg-light px-3 py-1')
+            .id('pathBuilderResult')
+            .pathWrapperClass('col-sm-7 border border-secondary rounded bg-light px-3 py-1')
             .buttonWrapperClass('col-sm-3')
             .buttonClass('btn btn-primary')
             .replace('#pathBuilderResult');

--- a/examples/WebCalendar/index.html
+++ b/examples/WebCalendar/index.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
         integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
         crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/virtual-select-plugin@1.1.0/dist/virtual-select.min.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.1/css/all.min.css"
         integrity="sha512-5Hs3dF2AEPkpNAR7UiOHba+lRSJNeM2ECkwxUIxC1Q/FLycGTbNapWXB4tP889k5T5Ju8fs4b1P5z/iB4nMfSQ=="
         crossorigin="anonymous"
@@ -29,6 +30,7 @@
         integrity="sha512-1JkMy1LR9bTo3psH+H4SV5bO2dFylgOy+UJhMus1zF4VEFuZVu5lsi4I6iIndE4N9p01z1554ZDcvMSjMaqCBQ=="
         crossorigin="anonymous"
         referrerpolicy="no-referrer"></script>
+    <script src="https://cdn.jsdelivr.net/npm/virtual-select-plugin@1.1.0/dist/virtual-select.min.js"></script>
     <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/examples/WebCalendar/main.css
+++ b/examples/WebCalendar/main.css
@@ -99,7 +99,7 @@
 }
 
 #LitCalTable td.red {
-    background-color: lightrose;
+    background-color: lightpink;
     color: black;
 }
 

--- a/examples/WebCalendar/main.css
+++ b/examples/WebCalendar/main.css
@@ -99,11 +99,11 @@
 }
 
 #LitCalTable td.red {
-    background-color: lightpink;
+    background-color: lightrose;
     color: black;
 }
 
-#LitCalTable td.pink {
+#LitCalTable td.rose {
     background-color: mistyrose;
     color: black;
 }
@@ -111,4 +111,18 @@
 #LitCalTable td.green {
     background-color: lightgreen;
     color: black;
+}
+
+.vscomp-toggle-button {
+    border-radius: var(--bs-border-radius);
+}
+
+.vscomp-ele[disabled] .vscomp-toggle-button {
+    background-color: var(--bs-secondary-bg);
+}
+
+.vscomp-wrapper.focused .vscomp-toggle-button, .vscomp-wrapper:focus .vscomp-toggle-button {
+    border-color: #86b7fe;
+    outline: 0;
+    box-shadow: 0 0 0 .25rem rgba(13, 110, 253, .25);
 }

--- a/examples/WebCalendar/main.js
+++ b/examples/WebCalendar/main.js
@@ -1,4 +1,4 @@
-import { ApiClient, CalendarSelect, ApiOptions, Input, WebCalendar, Grouping, ColorAs, Column, ColumnOrder, DateFormat, GradeDisplay } from '../../dist/index.js';
+import { ApiClient, CalendarSelect, ApiOptions, Input, WebCalendar, Grouping, ColorAs, Column, ColumnOrder, DateFormat, GradeDisplay } from '../../src/index.js';
 
 Input.setGlobalInputClass('form-select');
 Input.setGlobalLabelClass('form-label d-block mb-1');
@@ -7,6 +7,40 @@ Input.setGlobalWrapperClass('form-group col col-md-3');
 
 const lang = 'it-IT';
 const baseLang = lang.split('-')[0];
+
+function buildVirtualSelectOptions( selectElement ) {
+    return Array.from(selectElement.options).map(opt => ({
+        label: opt.textContent,
+        value: opt.value,
+        selected: opt.selected
+    }));
+}
+
+function buildAndInitVirtualSelectFromNativeSelect(nativeSelect, vsContainerId) {
+  // 1) build options and selected values
+  const opts = buildVirtualSelectOptions(nativeSelect);
+  const selectedValues = opts.filter(o => o.selected).map(o => o.value);
+
+  // 2) init VirtualSelect on the div container
+  VirtualSelect.init({
+    ele: `#${vsContainerId}`,
+    showValueAsTags: true,
+    //additionalToggleButtonClasses: "btn",
+    additionalDropboxContainerClasses: "dropdown-menu",
+    multiple: true,
+    search: false,
+    options: opts,
+    selectedValue: selectedValues,
+    onChange: function(value) {
+        // value is an array in multiple mode
+        // sync back to the native select
+        Array.from(nativeSelect.options).forEach(opt => {
+            opt.selected = value.includes(opt.value);
+        });
+        nativeSelect.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+  });
+}
 
 ApiClient.init('http://localhost:8000').then( (apiClient) => {
     const calendarSelect = new CalendarSelect( lang );
@@ -22,23 +56,53 @@ ApiClient.init('http://localhost:8000').then( (apiClient) => {
     apiOptions._localeInput.defaultValue( baseLang );
     apiOptions._acceptHeaderInput.hide();
     apiOptions._yearInput.class( 'form-control' ); // override the global input class
+    apiOptions._ascensionInput.wrapperClass( 'form-group col col-md-2' );
+    apiOptions._corpusChristiInput.wrapperClass( 'form-group col col-md-2' );
+    apiOptions._eternalHighPriestInput.wrapperClass( 'form-group col col-md-2' );
+    apiOptions._holydaysOfObligationInput.class('d-none');
     apiOptions.linkToCalendarSelect( calendarSelect ).appendTo( '#calendarOptions' );
 
     apiClient.listenTo( calendarSelect ).listenTo( apiOptions );
 
+    // 1. Create a new container element for the virtual select
+    const hdobVirtualSelect = document.createElement('div');
+    hdobVirtualSelect.id = 'hdob-virtual-select';
+    // 2. Insert it right after the original native select
+    apiOptions._holydaysOfObligationInput._domElement.parentNode.insertBefore( hdobVirtualSelect, apiOptions._holydaysOfObligationInput._domElement.nextSibling );
+    // 3. Build and initialize the virtual select from the native select
+    buildAndInitVirtualSelectFromNativeSelect( apiOptions._holydaysOfObligationInput._domElement, 'hdob-virtual-select' );
+    if (calendarSelect._domElement.value === '') {
+        hdobVirtualSelect.enable();
+    } else {
+        hdobVirtualSelect.disable();
+    }
+    // 4. Listen to changes on the calendar select to update the virtual select accordingly
+    calendarSelect._domElement.addEventListener('change', (ev) => {
+        console.log('calendar changed to:', ev.target.value);
+        const vsElement = document.querySelector('#hdob-virtual-select');
+        vsElement.destroy();
+        buildAndInitVirtualSelectFromNativeSelect( apiOptions._holydaysOfObligationInput._domElement, 'hdob-virtual-select' );
+        if (ev.target.value === '') {
+            vsElement.enable();
+        } else {
+            vsElement.disable();
+        }
+    });
+
     const webCalendar = new WebCalendar();
     webCalendar.id('LitCalTable')
-    .firstColumnGrouping(Grouping.BY_LITURGICAL_SEASON)
-    .psalterWeekColumn() // add psalter week column as the right hand most column
-    .removeHeaderRow() // we don't need to see the header row
-    .seasonColor(ColorAs.CSS_CLASS)
-    .seasonColorColumns(Column.LITURGICAL_SEASON)
-    .eventColor(ColorAs.INDICATOR)
-    .eventColorColumns(Column.EVENT_DETAILS)
-    .monthHeader() // enable month header at the start of each month
-    .dateFormat(DateFormat.DAY_ONLY)
-    .columnOrder(ColumnOrder.GRADE_FIRST)
-    .gradeDisplay(GradeDisplay.ABBREVIATED)
-    .attachTo( '#litcalWebcalendar' ) // the element in which the web calendar will be rendered, every time the calendar is updated
-    .listenTo(apiClient);
+                .firstColumnGrouping(Grouping.BY_LITURGICAL_SEASON)
+                .psalterWeekColumn() // add psalter week column as the right hand most column
+                .removeHeaderRow() // we don't need to see the header row
+                .seasonColor(ColorAs.CSS_CLASS)
+                .seasonColorColumns(Column.LITURGICAL_SEASON)
+                .eventColor(ColorAs.INDICATOR)
+                .eventColorColumns(Column.EVENT_DETAILS)
+                .monthHeader() // enable month header at the start of each month
+                .dateFormat(DateFormat.DAY_ONLY)
+                .columnOrder(ColumnOrder.GRADE_FIRST)
+                .gradeDisplay(GradeDisplay.ABBREVIATED)
+                .attachTo( '#litcalWebcalendar' ) // the element in which the web calendar will be rendered, every time the calendar is updated
+                .listenTo(apiClient);
+    apiClient.fetchNationalCalendar('VA');
 });

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "packageManager": "yarn@4.6.0",
   "name": "@liturgical-calendar/components-js",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": "John R. D'Orazio <priest@johnromanodorazio.com (https://www.johnromanodorazio.com)",
   "description": "Liturgical calendar components for javascript: an html select populated with liturgical calendars supported by the Liturgical Calendar API; form controls for parameters that are supported by the Liturgical Calendar API; a webcalendar; and liturgy of the day",
   "homepage": "https://litcal.johnromanodorazio.com",

--- a/src/ApiClient/ApiClient.js
+++ b/src/ApiClient/ApiClient.js
@@ -268,7 +268,7 @@ export default class ApiClient {
     // However, the only body param we need in this case is year_type,
     // so we also extract out all other params in order to discard them.
     const { year, epiphany, ascension, corpus_christi, eternal_high_priest, holydays_of_obligation, ...params } = this.#params;
-    this.#currentCategory = 'national';
+    this.#currentCategory   = 'national';
     this.#currentCalendarId = calendar_id;
     if (
       typeof locale === 'string'
@@ -395,28 +395,28 @@ export default class ApiClient {
     }
     apiOptions._epiphanyInput._domElement.addEventListener( 'change', event => {
       this.#params.epiphany = event.target.value;
-      console.log(`updated epiphany to ${this.#params.epiphany}`);
+      //console.log(`updated epiphany to ${this.#params.epiphany}`);
       if (this.#currentCategory === '') {
         this.refetchCalendarData();
       }
     });
     apiOptions._ascensionInput._domElement.addEventListener( 'change', event => {
       this.#params.ascension = event.target.value;
-      console.log(`updated ascension to ${this.#params.ascension}`);
+      //console.log(`updated ascension to ${this.#params.ascension}`);
       if (this.#currentCategory === '') {
         this.refetchCalendarData();
       }
     });
     apiOptions._corpusChristiInput._domElement.addEventListener( 'change', event => {
       this.#params.corpus_christi = event.target.value;
-      console.log(`updated corpus_christi to ${this.#params.corpus_christi}`);
+      //console.log(`updated corpus_christi to ${this.#params.corpus_christi}`);
       if (this.#currentCategory === '') {
         this.refetchCalendarData();
       }
     });
     apiOptions._eternalHighPriestInput._domElement.addEventListener( 'change', event => {
       this.#params.eternal_high_priest = event.target.value === 'true';
-      console.log(`updated eternal_high_priest to ${this.#params.eternal_high_priest}`);
+      //console.log(`updated eternal_high_priest to ${this.#params.eternal_high_priest}`);
       if (this.#currentCategory === '') {
         this.refetchCalendarData();
       }
@@ -426,24 +426,24 @@ export default class ApiClient {
         Array.from(event.target.options, opt => [opt.value, opt.selected])
       );
       this.#params.holydays_of_obligation = selectedStates;
-      console.log(`updated holydays_of_obligation to ${this.#params.holydays_of_obligation}`);
+      //console.log('updated holydays_of_obligation to:', this.#params.holydays_of_obligation);
       if (this.#currentCategory === '') {
         this.refetchCalendarData();
       }
     });
     apiOptions._yearInput._domElement.addEventListener( 'change', event => {
-      this.#params.year = event.target.value;
-      console.log(`updated year to ${this.#params.year}`);
+      this.#params.year = parseInt(event.target.value, 10);
+      //console.log(`updated year to ${this.#params.year}`);
       this.refetchCalendarData();
     });
     apiOptions._yearTypeInput._domElement.addEventListener( 'change', event => {
       this.#params.year_type = event.target.value;
-      console.log(`updated year_type to ${this.#params.year_type}`);
+      //console.log(`updated year_type to ${this.#params.year_type}`);
       this.refetchCalendarData();
     });
     apiOptions._localeInput._domElement.addEventListener( 'change', event => {
       this.#fetchCalendarHeaders['Accept-Language'] = event.target.value;
-      console.log(`updated locale to ${this.#fetchCalendarHeaders['Accept-Language']}`);
+      //console.log(`updated locale to ${this.#fetchCalendarHeaders['Accept-Language']}`);
       this.refetchCalendarData();
     });
     return this;

--- a/src/ApiClient/ApiClient.js
+++ b/src/ApiClient/ApiClient.js
@@ -79,7 +79,7 @@ export default class ApiClient {
 
   /**
    * Parameters for the API request sent as a JSON object representing key - value pairs, in the body of the request
-   * @type {{year: number, epiphany: string, ascension: string, corpus_christi: string, year_type: string, eternal_high_priest: boolean}}
+   * @type {{year: number, epiphany: string, ascension: string, corpus_christi: string, year_type: string, eternal_high_priest: boolean, holydays_of_obligation: {[key: string]: boolean}}}
    */
   #params = {
     year: new Date().getFullYear(),
@@ -87,6 +87,18 @@ export default class ApiClient {
     ascension: 'THURSDAY',
     corpus_christi: 'THURSDAY',
     eternal_high_priest: false,
+    holydays_of_obligation: {
+      "Christmas": true,
+      "Epiphany": true,
+      "Ascension": true,
+      "CorpusChristi": true,
+      "MaryMotherOfGod": true,
+      "ImmaculateConception": true,
+      "Assumption": true,
+      "StJoseph": true,
+      "StsPeterPaulAp": true,
+      "AllSaints": true
+    },
     year_type: YearType.LITURGICAL
   };
 
@@ -255,7 +267,7 @@ export default class ApiClient {
     // Since the year parameter will be placed in the path, we extract it from the body params.
     // However, the only body param we need in this case is year_type,
     // so we also extract out all other params in order to discard them.
-    const { year, epiphany, ascension, corpus_christi, eternal_high_priest, ...params } = this.#params;
+    const { year, epiphany, ascension, corpus_christi, eternal_high_priest, holydays_of_obligation, ...params } = this.#params;
     this.#currentCategory = 'national';
     this.#currentCalendarId = calendar_id;
     if (
@@ -302,7 +314,7 @@ export default class ApiClient {
     // Since the year parameter will be placed in the path, we extract it from the body params.
     // However, the only body param we need in this case is year_type,
     // so we also extract out all other params in order to discard them.
-    const { year, epiphany, ascension, corpus_christi, eternal_high_priest, ...params } = this.#params;
+    const { year, epiphany, ascension, corpus_christi, eternal_high_priest, holydays_of_obligation, ...params } = this.#params;
     this.#currentCategory = 'diocesan';
     this.#currentCalendarId = calendar_id;
     fetch(`${ApiClient.#apiUrl}${ApiClient.#paths.calendar}/diocese/${calendar_id}${year ? `/${year}` : ''}`, {
@@ -405,6 +417,16 @@ export default class ApiClient {
     apiOptions._eternalHighPriestInput._domElement.addEventListener( 'change', event => {
       this.#params.eternal_high_priest = event.target.value === 'true';
       console.log(`updated eternal_high_priest to ${this.#params.eternal_high_priest}`);
+      if (this.#currentCategory === '') {
+        this.refetchCalendarData();
+      }
+    });
+    apiOptions._holydaysOfObligationInput._domElement.addEventListener( 'change', event => {
+      const selectedStates = Object.fromEntries(
+        Array.from(event.target.options, opt => [opt.value, opt.selected])
+      );
+      this.#params.holydays_of_obligation = selectedStates;
+      console.log(`updated holydays_of_obligation to ${this.#params.holydays_of_obligation}`);
       if (this.#currentCategory === '') {
         this.refetchCalendarData();
       }

--- a/src/ApiOptions/ApiOptions.js
+++ b/src/ApiOptions/ApiOptions.js
@@ -24,7 +24,7 @@ import Utils from '../Utils.js';
  *                                             - __locale__: The locale to use for the API options form.
  *
  * The following properties are initialized on the object instance:
- * - ___epiphanyInput__: The seslect input with options for when the Epiphany is celebrated.
+ * - ___epiphanyInput__: The select input with options for when the Epiphany is celebrated.
  * - ___ascensionInput__: The select input with options for when the Ascension is celebrated.
  * - ___corpusChristiInput__: The select input with options for when Corpus Christi is celebrated.
  * - ___eternalHighPriestInput__: The select input with options for whether the Eternal High Priest is celebrated.

--- a/src/ApiOptions/ApiOptions.js
+++ b/src/ApiOptions/ApiOptions.js
@@ -20,8 +20,8 @@ import Utils from '../Utils.js';
  *
  * The form controls can be fully customized using the methods provided by the class.
  *
- * __ constructor()__ Initializes the ApiOptions object with default or provided settings:
- *                                             - __locale__: The locale to use for the API options form.
+ * - __constructor()__ Initializes the ApiOptions object with default or provided settings:
+ *   - __locale__: The locale to use for the API options form.
  *
  * The following properties are initialized on the object instance:
  * - ___epiphanyInput__: The select input with options for when the Epiphany is celebrated.
@@ -288,29 +288,7 @@ export default class ApiOptions {
                     const nationalCalendarForDiocese = ApiClient._metadata.national_calendars.filter(nationCalendarObj => nationCalendarObj.calendar_id === nation)[0];
                     const nationalCalendarForDioceseSettings = nationalCalendarForDiocese.settings;
                     //console.info('handling national calendar settings for diocesan calendar while linking to calendar select:', nationalCalendarForDioceseSettings);
-                    Object.entries(nationalCalendarForDioceseSettings).forEach(([key, value]) => {
-                        // skip keys that are not expected, so that the script doesn't break when an unexpected key is encountered
-                        if (!ApiOptions.#expectedSettingsKeys.includes(key)) {
-                            return;
-                        }
-                        // transform the key from snake_case to camelCase
-                        key = key.replaceAll('_', ' ');
-                        key = key.split(' ').map((word, index) => index === 0 ? word.charAt(0).toLowerCase() + word.slice(1) : word.charAt(0).toUpperCase() + word.slice(1)).join('');
-                        //console.log(`national settings for diocesan calendar: transformed key: ${key}, value type: ${typeof value}`);
-                        if (typeof value === 'boolean') {
-                            value = (value ? 'true' : 'false');
-                        }
-                        if (key === 'holydaysOfObligation' && typeof value === 'object') {
-                            const optionsArray = Object.entries(value).map(([optionKey, optionSelected]) => ({
-                                label: ApiOptions.#prettifyLabel(optionKey),
-                                value: optionKey,
-                                selected: Boolean(optionSelected)
-                            }));
-                            this.#inputs[`${key}Input`].setOptions(optionsArray);
-                        } else {
-                            this.#inputs[`${key}Input`]._domElement.value = value;
-                        }
-                    });
+                    this.#applySettingsToInputs(nationalCalendarForDioceseSettings);
                     if (selectedDiocesanCalendar.hasOwnProperty('settings')) {
                         const {settings} = selectedDiocesanCalendar;
                         //console.info('handling diocesan calendar settings while linking to calendar select:', settings);

--- a/src/ApiOptions/ApiOptions.js
+++ b/src/ApiOptions/ApiOptions.js
@@ -5,6 +5,7 @@ import {
     EpiphanyInput,
     LocaleInput,
     EternalHighPriestInput,
+    HolydaysOfObligationInput,
     YearInput,
     YearTypeInput,
     CalendarPathInput
@@ -27,6 +28,7 @@ import Utils from '../Utils.js';
  * - ___ascensionInput__: The select input with options for when the Ascension is celebrated.
  * - ___corpusChristiInput__: The select input with options for when Corpus Christi is celebrated.
  * - ___eternalHighPriestInput__: The select input with options for whether the Eternal High Priest is celebrated.
+ * - ___holydaysOfObligationInput__: The select input with options for which holy days of obligation are observed.
  * - ___yearTypeInput__: The select input with options for the type of year to produce, whether liturgical or civil.
  * - ___localeInput__: The select input with options for the locale to use for the calendar response from the API.
  * - ___acceptHeaderInput__: The select input with options for the Accept header to use for the calendar response from the API.
@@ -46,6 +48,18 @@ import Utils from '../Utils.js';
  */
 export default class ApiOptions {
 
+    /** @type {string[]} */
+    static #expectedSettingsKeys = [
+        'year',
+        'year_type',
+        'locale',
+        'epiphany',
+        'ascension',
+        'corpus_christi',
+        'eternal_high_priest',
+        'holydays_of_obligation'
+    ];
+
     /** @type {boolean} */
     #linked                = false;
 
@@ -61,6 +75,7 @@ export default class ApiOptions {
      *  ascensionInput: ?AscensionInput,
      *  corpusChristiInput: ?CorpusChristiInput,
      *  eternalHighPriestInput: ?EternalHighPriestInput,
+     *  holydaysOfObligationInput: ?HolydaysOfObligationInput,
      *  localeInput: ?LocaleInput,
      *  yearInput: ?YearInput,
      *  yearTypeInput: ?YearTypeInput,
@@ -73,6 +88,7 @@ export default class ApiOptions {
         ascensionInput: null,
         corpusChristiInput: null,
         eternalHighPriestInput: null,
+        holydaysOfObligationInput: null,
         localeInput: null,
         yearInput: null,
         yearTypeInput: null,
@@ -103,11 +119,34 @@ export default class ApiOptions {
         this.#inputs.ascensionInput = new AscensionInput(this.#locale);
         this.#inputs.corpusChristiInput = new CorpusChristiInput(this.#locale);
         this.#inputs.eternalHighPriestInput = new EternalHighPriestInput(this.#locale);
+        this.#inputs.holydaysOfObligationInput = new HolydaysOfObligationInput();
         this.#inputs.localeInput = new LocaleInput(this.#locale);
         this.#inputs.yearInput = new YearInput();
         this.#inputs.yearTypeInput = new YearTypeInput(this.#locale);
         this.#inputs.acceptHeaderInput = new AcceptHeaderInput();
         this.#inputs.calendarPathInput = new CalendarPathInput(this.#locale);
+    }
+
+    /**
+     * Basic heuristic to make labels human-friendly
+     *
+     * TODO: It would be even better to retrieve the actual "name" of the corresponding liturgical events from the current calendar,
+     *       but this would require fetching the calendar data first, which is not ideal.
+     *       So for now, this private method just applies some basic transformations to make the keys more readable.
+     *       We don't have access to any calendar data in ApiClient._calendarData, because it is not a static property, it is an instance property.
+     *       Had we access to that instance property, given that it were available, we could search through the calendar data to find the corresponding event names.
+     *
+     * @param {string} key
+     * @returns {string}
+     */
+    static #prettifyLabel(key) {
+        return key
+            .replace(/([A-Z])/g, ' $1')
+            .replace(/^./, s => s.toUpperCase())
+            .trim()
+            .replace(/^(St(?:s?))/, '$1.')
+            .replace('Mary Mother Of God', 'Mary, Mother of God')
+            .replace('Peter Paul Ap', 'Peter and Paul, Apostles');
     }
 
     // TODO: add support for multiple linked calendar selects
@@ -123,12 +162,14 @@ export default class ApiOptions {
                 this.#inputs.ascensionInput.disabled(false);
                 this.#inputs.corpusChristiInput.disabled(false);
                 this.#inputs.eternalHighPriestInput.disabled(false);
+                this.#inputs.holydaysOfObligationInput.disabled(false);
             } else {
                 // all API options disabled
                 this.#inputs.epiphanyInput.disabled(true);
                 this.#inputs.ascensionInput.disabled(true);
                 this.#inputs.corpusChristiInput.disabled(true);
                 this.#inputs.eternalHighPriestInput.disabled(true);
+                this.#inputs.holydaysOfObligationInput.disabled(true);
             }
         });
         dioceseSelector._domElement.addEventListener('change', (ev) => {
@@ -140,12 +181,14 @@ export default class ApiOptions {
                 this.#inputs.ascensionInput.disabled(false);
                 this.#inputs.corpusChristiInput.disabled(false);
                 this.#inputs.eternalHighPriestInput.disabled(false);
+                this.#inputs.holydaysOfObligationInput.disabled(false);
             } else {
                 // all API options disabled
                 this.#inputs.epiphanyInput.disabled(true);
                 this.#inputs.ascensionInput.disabled(true);
                 this.#inputs.corpusChristiInput.disabled(true);
                 this.#inputs.eternalHighPriestInput.disabled(true);
+                this.#inputs.holydaysOfObligationInput.disabled(true);
             }
         });
     }
@@ -161,6 +204,7 @@ export default class ApiOptions {
      * @private
      */
     #handleSingleLinkedCalendarSelect(calendarSelect) {
+        console.log('handling single linked calendar select', calendarSelect, this.#filtersSet);
         if (this.#filtersSet.includes(ApiOptionsFilter.PATH_BUILDER)) {
             calendarSelect.allowNull(false).disabled()._domElement.innerHTML = '<option value="">GENERAL ROMAN</option>';
             let lastCalendarPathValue = this.#inputs.calendarPathInput._domElement.value;
@@ -170,7 +214,7 @@ export default class ApiOptions {
                     lastCalendarPathValue = ev.target.value;
                     switch (ev.target.value) {
                         case '/calendar':
-                            calendarSelect.disabled()._domElement.innerHTML = '<option value="">GENERAL ROMAN</option>';
+                            calendarSelect.disabled(true)._domElement.innerHTML = '<option value="">GENERAL ROMAN</option>';
                             break;
                         case '/calendar/nation/':
                             calendarSelect.disabled(false).filter(CalendarSelectFilter.NATIONAL_CALENDARS);
@@ -194,14 +238,29 @@ export default class ApiOptions {
                 case 'national': {
                     const selectedNationalCalendar = ApiClient._metadata.national_calendars.filter(nationCalendarObj => nationCalendarObj.calendar_id === currentSelectedCalendarId)[0];
                     const {settings, locales} = selectedNationalCalendar;
+                    //console.info('handling national calendar settings while linking to calendar select:', settings);
                     Object.entries(settings).forEach(([key, value]) => {
+                        // skip keys that are not expected, so that the script doesn't break when an unexpected key is encountered
+                        if (!ApiOptions.#expectedSettingsKeys.includes(key)) {
+                            return;
+                        }
                         // transform the key from snake_case to camelCase
                         key = key.replaceAll('_', ' ');
                         key = key.split(' ').map((word, index) => index === 0 ? word.charAt(0).toLowerCase() + word.slice(1) : word.charAt(0).toUpperCase() + word.slice(1)).join('');
+                        //console.log(`national settings: transformed key: ${key}, value type: ${typeof value}`);
                         if (typeof value === 'boolean') {
-                            value = value ? 'true' : 'false';
+                            value = (value ? 'true' : 'false');
                         }
-                        this.#inputs[`${key}Input`]._domElement.value = value;
+                        if (key === 'holydaysOfObligation' && typeof value === 'object') {
+                            const optionsArray = Object.entries(value).map(([optionKey, optionSelected]) => ({
+                                label: ApiOptions.#prettifyLabel(optionKey),
+                                value: optionKey,
+                                selected: Boolean(optionSelected)
+                            }));
+                            this.#inputs[`${key}Input`].setOptions(optionsArray);
+                        } else {
+                            this.#inputs[`${key}Input`]._domElement.value = value;
+                        }
                     });
                     this.#inputs.localeInput.setOptionsForCalendarLocales(locales);
                     break;
@@ -211,21 +270,42 @@ export default class ApiOptions {
                     const {nation, locales} = selectedDiocesanCalendar;
                     const nationalCalendarForDiocese = ApiClient._metadata.national_calendars.filter(nationCalendarObj => nationCalendarObj.calendar_id === nation)[0];
                     const nationalCalendarForDioceseSettings = nationalCalendarForDiocese.settings;
+                    //console.info('handling national calendar settings for diocesan calendar while linking to calendar select:', nationalCalendarForDioceseSettings);
                     Object.entries(nationalCalendarForDioceseSettings).forEach(([key, value]) => {
+                        // skip keys that are not expected, so that the script doesn't break when an unexpected key is encountered
+                        if (!ApiOptions.#expectedSettingsKeys.includes(key)) {
+                            return;
+                        }
                         // transform the key from snake_case to camelCase
                         key = key.replaceAll('_', ' ');
                         key = key.split(' ').map((word, index) => index === 0 ? word.charAt(0).toLowerCase() + word.slice(1) : word.charAt(0).toUpperCase() + word.slice(1)).join('');
+                        //console.log(`national settings for diocesan calendar: transformed key: ${key}, value type: ${typeof value}`);
                         if (typeof value === 'boolean') {
-                            value = value ? 'true' : 'false';
+                            value = (value ? 'true' : 'false');
                         }
-                        this.#inputs[`${key}Input`]._domElement.value = value;
+                        if (key === 'holydaysOfObligation' && typeof value === 'object') {
+                            const optionsArray = Object.entries(value).map(([optionKey, optionSelected]) => ({
+                                label: ApiOptions.#prettifyLabel(optionKey),
+                                value: optionKey,
+                                selected: Boolean(optionSelected)
+                            }));
+                            this.#inputs[`${key}Input`].setOptions(optionsArray);
+                        } else {
+                            this.#inputs[`${key}Input`]._domElement.value = value;
+                        }
                     });
                     if (selectedDiocesanCalendar.hasOwnProperty('settings')) {
                         const {settings} = selectedDiocesanCalendar;
+                        console.info('handling diocesan calendar settings while linking to calendar select:', settings);
                         Object.entries(settings).forEach(([key, value]) => {
+                            // skip keys that are not expected, so that the script doesn't break when an unexpected key is encountered
+                            if (!ApiOptions.#expectedSettingsKeys.includes(key)) {
+                                return;
+                            }
                             // transform the key from snake_case to camelCase
                             key = key.replaceAll('_', ' ');
                             key = key.split(' ').map((word, index) => index === 0 ? word.charAt(0).toLowerCase() + word.slice(1) : word.charAt(0).toUpperCase() + word.slice(1)).join('');
+                            //console.log(`diocesan settings: transformed key: ${key}, value type: ${typeof value}`);
                             if (typeof value === 'boolean') {
                                 value = value ? 'true' : 'false';
                             }
@@ -242,22 +322,23 @@ export default class ApiOptions {
             this.#inputs.ascensionInput.disabled(true);
             this.#inputs.corpusChristiInput.disabled(true);
             this.#inputs.eternalHighPriestInput.disabled(true);
+            this.#inputs.holydaysOfObligationInput.disabled(true);
         } else {
             this.#inputs.epiphanyInput.disabled(false);
             this.#inputs.ascensionInput.disabled(false);
             this.#inputs.corpusChristiInput.disabled(false);
             this.#inputs.eternalHighPriestInput.disabled(false);
+            this.#inputs.holydaysOfObligationInput.disabled(false);
             this.#inputs.localeInput.resetOptions();
         }
         calendarSelect._domElement.addEventListener('change', (ev) => {
-            // TODO: set selected values based on selected calendar
-            // TODO: set available options for locale select based on selected calendar
             if (ev.target.value === '') {
                 // all API options enabled
                 this.#inputs.epiphanyInput.disabled(false);
                 this.#inputs.ascensionInput.disabled(false);
                 this.#inputs.corpusChristiInput.disabled(false);
                 this.#inputs.eternalHighPriestInput.disabled(false);
+                this.#inputs.holydaysOfObligationInput.disabled(false);
                 this.#inputs.localeInput.resetOptions();
             } else {
                 const selectedCalendarType = calendarSelect._domElement.querySelector(':checked').getAttribute('data-calendartype');
@@ -265,14 +346,30 @@ export default class ApiOptions {
                     case 'national': {
                         const selectedNationalCalendar = ApiClient._metadata.national_calendars.filter(nationCalendarObj => nationCalendarObj.calendar_id === ev.target.value)[0];
                         const {settings, locales} = selectedNationalCalendar;
+                        //console.info('handling national calendar settings following change event:', settings);
                         Object.entries(settings).forEach(([key, value]) => {
+                            // skip keys that are not expected, so that the script doesn't break when an unexpected key is encountered
+                            if (!ApiOptions.#expectedSettingsKeys.includes(key)) {
+                                return;
+                            }
+                            //console.log(`key: ${key}, value: ${value}`);
                             // transform the key from snake_case to camelCase
                             key = key.replaceAll('_', ' ');
                             key = key.split(' ').map((word, index) => index === 0 ? word.charAt(0).toLowerCase() + word.slice(1) : word.charAt(0).toUpperCase() + word.slice(1)).join('');
+                            //console.log(`national settings: transformed key: ${key}, value type: ${typeof value}`);
                             if (typeof value === 'boolean') {
                                 value = value ? 'true' : 'false';
                             }
-                            this.#inputs[`${key}Input`]._domElement.value = value;
+                            if (key === 'holydaysOfObligation' && typeof value === 'object') {
+                                const optionsArray = Object.entries(value).map(([optionKey, optionSelected]) => ({
+                                    label: ApiOptions.#prettifyLabel(optionKey),
+                                    value: optionKey,
+                                    selected: Boolean(optionSelected)
+                                }));
+                                this.#inputs[`${key}Input`].setOptions(optionsArray);
+                            } else {
+                                this.#inputs[`${key}Input`]._domElement.value = value;
+                            }
                         });
                         this.#inputs.localeInput.setOptionsForCalendarLocales(locales);
                         this.#inputs.localeInput._domElement.dispatchEvent(new Event('change'));
@@ -283,21 +380,42 @@ export default class ApiOptions {
                         const {nation, locales} = selectedDiocese;
                         const nationalCalendarForDiocese = ApiClient._metadata.national_calendars.filter(nationCalendarObj => nationCalendarObj.calendar_id === nation)[0];
                         const nationalCalendarForDioceseSettings = nationalCalendarForDiocese.settings;
+                        //console.info('handling national calendar settings for diocesan calendar following change event:', nationalCalendarForDioceseSettings);
                         Object.entries(nationalCalendarForDioceseSettings).forEach(([key, value]) => {
+                            // skip keys that are not expected, so that the script doesn't break when an unexpected key is encountered
+                            if (!ApiOptions.#expectedSettingsKeys.includes(key)) {
+                                return;
+                            }
                             // transform the key from snake_case to camelCase
                             key = key.replaceAll('_', ' ');
                             key = key.split(' ').map((word, index) => index === 0 ? word.charAt(0).toLowerCase() + word.slice(1) : word.charAt(0).toUpperCase() + word.slice(1)).join('');
+                            //console.log(`national settings for diocesan calendar: transformed key: ${key}, value type: ${typeof value}`);
                             if (typeof value === 'boolean') {
                                 value = value ? 'true' : 'false';
                             }
-                            this.#inputs[`${key}Input`]._domElement.value = value;
+                            if (key === 'holydaysOfObligation' && typeof value === 'object') {
+                                const optionsArray = Object.entries(value).map(([optionKey, optionSelected]) => ({
+                                    label: ApiOptions.#prettifyLabel(optionKey),
+                                    value: optionKey,
+                                    selected: Boolean(optionSelected)
+                                }));
+                                this.#inputs[`${key}Input`].setOptions(optionsArray);
+                            } else {
+                                this.#inputs[`${key}Input`]._domElement.value = value;
+                            }
                         });
                         if (selectedDiocese.hasOwnProperty('settings')) {
                             const {settings} = selectedDiocese;
+                            //console.info('handling diocesan calendar settings following change event:', settings);
                             Object.entries(settings).forEach(([key, value]) => {
+                                // skip keys that are not expected, so that the script doesn't break when an unexpected key is encountered
+                                if (!ApiOptions.#expectedSettingsKeys.includes(key)) {
+                                    return;
+                                }
                                 // transform the key from snake_case to camelCase
                                 key = key.replaceAll('_', ' ');
                                 key = key.split(' ').map((word, index) => index === 0 ? word.charAt(0).toLowerCase() + word.slice(1) : word.charAt(0).toUpperCase() + word.slice(1)).join('');
+                                //console.log(`diocesan settings: transformed key: ${key}, value type: ${typeof value}`);
                                 if (typeof value === 'boolean') {
                                     value = value ? 'true' : 'false';
                                 }
@@ -314,6 +432,7 @@ export default class ApiOptions {
                 this.#inputs.ascensionInput.disabled(true);
                 this.#inputs.corpusChristiInput.disabled(true);
                 this.#inputs.eternalHighPriestInput.disabled(true);
+                this.#inputs.holydaysOfObligationInput.disabled(true);
             }
         });
     }
@@ -375,7 +494,7 @@ export default class ApiOptions {
      * `dioceses` filtered CalendarSelect. When the selected calendar is changed in either of the two CalendarSelect
      * instances, the API options will be updated accordingly.
      * @param {CalendarSelect | [CalendarSelect, CalendarSelect]} calendarSelect - The CalendarSelect instance or
-     * an array of two CalendarSelect instances to link to the ApiOptions instance.
+     * an array of two CalendarSelect instances (one for nations and one for dioceses) to link to the ApiOptions instance.
      * @returns {ApiOptions} - The ApiOptions instance.
      */
     linkToCalendarSelect(calendarSelect) {
@@ -452,6 +571,7 @@ export default class ApiOptions {
             this.#inputs.ascensionInput.appendTo(domNode);
             this.#inputs.corpusChristiInput.appendTo(domNode);
             this.#inputs.eternalHighPriestInput.appendTo(domNode);
+            this.#inputs.holydaysOfObligationInput.appendTo(domNode);
         }
         // This should only be the case when no filter has been set explicitly via the filter method,
         // and therefore this.#filter = ApiOptionsFilter.NONE
@@ -498,6 +618,16 @@ export default class ApiOptions {
      */
     get _eternalHighPriestInput() {
         return this.#inputs.eternalHighPriestInput;
+    }
+
+    /**
+     * Gets the Holydays of Obligation input element.
+     *
+     * @returns {HolydaysOfObligationInput} The Holydays of Obligation input element.
+     * @readonly
+     */
+    get _holydaysOfObligationInput() {
+        return this.#inputs.holydaysOfObligationInput;
     }
 
     /**

--- a/src/ApiOptions/Input/AcceptHeaderInput.js
+++ b/src/ApiOptions/Input/AcceptHeaderInput.js
@@ -32,6 +32,7 @@ export default class AcceptHeaderInput extends SelectInput {
         this._domElement.name = 'return_type';
         this._domElement.id = 'return_type';
         this._labelElement.textContent = this.#asReturnTypeParam ? 'return_type' : 'Accept Header';
+        this._labelElement.htmlFor = this._domElement.id;
         if (AcceptHeaderInput.#returnTypeOptions.length === 0) {
             AcceptHeaderInput.#returnTypeOptions = AcceptHeaderInput.#RETURN_TYPE_PARAM_VALS.map(value => {
                 const option = document.createElement('option');

--- a/src/ApiOptions/Input/AscensionInput.js
+++ b/src/ApiOptions/Input/AscensionInput.js
@@ -21,6 +21,7 @@ export default class AscensionInput extends SelectInput {
         this._domElement.name = 'ascension';
         this._domElement.id = 'ascension';
         this._labelElement.textContent = 'ascension';
+        this._labelElement.htmlFor = this._domElement.id;
         if (locale === null) {
             throw new Error('Locale cannot be null.');
         }

--- a/src/ApiOptions/Input/CalendarPathInput.js
+++ b/src/ApiOptions/Input/CalendarPathInput.js
@@ -21,6 +21,7 @@ export default class CalendarPathInput extends SelectInput {
         this._domElement.name = 'calendar_path';
         this._domElement.id = 'calendar_path';
         this._labelElement.textContent = Messages[locale.language]['SELECT_ROUTE'] ?? 'Select route';
+        this._labelElement.htmlFor = this._domElement.id;
         this._domElement.append(...CalendarPathInput.#CALENDAR_PATHS.map(path => {
             const option = document.createElement('option');
             option.textContent = path;

--- a/src/ApiOptions/Input/CorpusChristiInput.js
+++ b/src/ApiOptions/Input/CorpusChristiInput.js
@@ -20,6 +20,7 @@ export default class CorpusChristiInput extends SelectInput {
         this._domElement.name = 'corpus_christi';
         this._domElement.id = 'corpus_christi';
         this._labelElement.textContent = 'corpus_christi';
+        this._labelElement.htmlFor = this._domElement.id;
         if (locale === null) {
             throw new Error('Locale cannot be null.');
         }

--- a/src/ApiOptions/Input/EpiphanyInput.js
+++ b/src/ApiOptions/Input/EpiphanyInput.js
@@ -21,6 +21,7 @@ export default class EpiphanyInput extends SelectInput {
         this._domElement.name = 'epiphany';
         this._domElement.id = 'epiphany';
         this._labelElement.textContent = 'epiphany';
+        this._labelElement.htmlFor = this._domElement.id;
         if (locale === null) {
             throw new Error('Locale cannot be null.');
         }

--- a/src/ApiOptions/Input/EternalHighPriestInput.js
+++ b/src/ApiOptions/Input/EternalHighPriestInput.js
@@ -22,6 +22,7 @@ export default class EternalHighPriestInput extends SelectInput {
         this._domElement.name = 'eternal_high_priest';
         this._domElement.id = 'eternal_high_priest';
         this._labelElement.textContent = 'eternal_high_priest';
+        this._labelElement.htmlFor = this._domElement.id;
         if (locale === null) {
             throw new Error('Locale cannot be null.');
         }

--- a/src/ApiOptions/Input/HolydaysOfObligation.js
+++ b/src/ApiOptions/Input/HolydaysOfObligation.js
@@ -1,0 +1,99 @@
+import SelectInput from "./SelectInput.js";
+import Messages from "../../Messages.js";
+
+export default class HolydaysOfObligationInput extends SelectInput {
+
+    #options = null;
+
+    static BASE_OPTIONS = [
+        { value: "Christmas",            label: "Christmas",                     selected: true },
+        { value: "Epiphany",             label: "Epiphany",                      selected: true },
+        { value: "Ascension",            label: "Ascension",                     selected: true },
+        { value: "CorpusChristi",        label: "Corpus Christi",                selected: true },
+        { value: "MaryMotherOfGod",      label: "Mary, Mother of God",           selected: true },
+        { value: "ImmaculateConception", label: "Immaculate Conception",         selected: true },
+        { value: "Assumption",           label: "Assumption",                    selected: true },
+        { value: "StJoseph",             label: "St. Joseph",                    selected: true },
+        { value: "StsPeterPaulAp",       label: "Sts. Peter and Paul, Apostles", selected: true },
+        { value: "AllSaints",            label: "All Saints",                    selected: true },
+    ];
+
+    static mergeOptions(customOptions) {
+        if (!Array.isArray(customOptions) || customOptions.length === 0) {
+            return HolydaysOfObligationInput.BASE_OPTIONS;
+        }
+
+        // Convert custom options into a map for quick lookup
+        const customMap = new Map(customOptions.map(opt => [opt.value, opt]));
+
+        // Start from base options, merge overrides, and include any new ones
+        const merged = [
+        ...HolydaysOfObligationInput.BASE_OPTIONS.map(base => ({
+            ...base,
+            ...(customMap.get(base.value) || {}),
+        })),
+        ...customOptions.filter(opt => !HolydaysOfObligationInput.BASE_OPTIONS.some(b => b.value === opt.value))
+        ];
+
+        return merged;
+    }
+
+    setOptions(options) {
+        console.info('setting holy days of obligation options:', options);
+        this.#options = Object.freeze(HolydaysOfObligationInput.mergeOptions(options));
+        // Clear existing options
+        while (this._domElement.firstChild) {
+            this._domElement.removeChild(this._domElement.firstChild);
+        }
+        // Add new options
+        this.#options.forEach(({ label, value, selected }) => {
+            const optionElement = document.createElement('option');
+            optionElement.value = value;
+            optionElement.title = value;
+            optionElement.textContent = label;
+            if (selected) {
+                optionElement.setAttribute('selected', 'selected');
+            }
+            this._domElement.appendChild(optionElement);
+        });
+    }
+
+    get _options() {
+        return this.#options;
+    }
+
+    /**
+     * Constructs an HolydaysOfObligationInput object.
+     *
+     * @param {Array<{value:string,label:string,selected:boolean}>} options - An array of objects where each object has the following properties:
+     *   - value: The value attribute for the option element.
+     *   - label: The text content for the option element.
+     *   - selected: A boolean indicating whether the option is selected by default (i.e. whether the liturgical event is celebrated as a holy day of obligation or not).
+     * @throws {Error} Throws an error if the locale is null or not an instance of Intl.Locale.
+     *
+     * This constructor initializes the holy days of obligation input select element, setting its name, id, and
+     * label text content, with the multiple attribute set to true.
+     * It also populates the select options with a minimal set of base options merged with any provided custom options,
+     * which can override the base options. The options are immutable and each option's
+     * selected state is determined by the `selected` boolean property for each option.
+     */
+    constructor(options = []) {
+        super(true);
+        this._domElement.name = 'holydays_of_obligation';
+        this._domElement.id = 'holydays_of_obligation';
+        this._labelElement.textContent = 'holydays_of_obligation';
+        this._labelElement.htmlFor = this._domElement.id;
+        this.#options = Object.freeze(HolydaysOfObligationInput.mergeOptions(options));
+        this.#options.forEach(({ label, value, selected }) => {
+            const optionElement = document.createElement('option');
+            optionElement.value = value;
+            optionElement.title = value;
+            optionElement.textContent = label;
+            if (selected) {
+                optionElement.setAttribute('selected', 'selected');
+            }
+            this._domElement.appendChild(optionElement);
+        });
+    }
+
+}

--- a/src/ApiOptions/Input/HolydaysOfObligation.js
+++ b/src/ApiOptions/Input/HolydaysOfObligation.js
@@ -1,27 +1,32 @@
 import SelectInput from "./SelectInput.js";
-import Messages from "../../Messages.js";
+//import Messages from "../../Messages.js";
 
 export default class HolydaysOfObligationInput extends SelectInput {
 
     #options = null;
 
-    static BASE_OPTIONS = [
-        { value: "Christmas",            label: "Christmas",                     selected: true },
-        { value: "Epiphany",             label: "Epiphany",                      selected: true },
-        { value: "Ascension",            label: "Ascension",                     selected: true },
-        { value: "CorpusChristi",        label: "Corpus Christi",                selected: true },
-        { value: "MaryMotherOfGod",      label: "Mary, Mother of God",           selected: true },
-        { value: "ImmaculateConception", label: "Immaculate Conception",         selected: true },
-        { value: "Assumption",           label: "Assumption",                    selected: true },
-        { value: "StJoseph",             label: "St. Joseph",                    selected: true },
-        { value: "StsPeterPaulAp",       label: "Sts. Peter and Paul, Apostles", selected: true },
-        { value: "AllSaints",            label: "All Saints",                    selected: true },
-    ];
+    static BASE_OPTIONS = Object.freeze([
+        Object.freeze({ value: "Christmas",            label: "Christmas",                     selected: true }),
+        Object.freeze({ value: "Epiphany",             label: "Epiphany",                      selected: true }),
+        Object.freeze({ value: "Ascension",            label: "Ascension",                     selected: true }),
+        Object.freeze({ value: "CorpusChristi",        label: "Corpus Christi",                selected: true }),
+        Object.freeze({ value: "MaryMotherOfGod",      label: "Mary, Mother of God",           selected: true }),
+        Object.freeze({ value: "ImmaculateConception", label: "Immaculate Conception",         selected: true }),
+        Object.freeze({ value: "Assumption",           label: "Assumption",                    selected: true }),
+        Object.freeze({ value: "StJoseph",             label: "St. Joseph",                    selected: true }),
+        Object.freeze({ value: "StsPeterPaulAp",       label: "Sts. Peter and Paul, Apostles", selected: true }),
+        Object.freeze({ value: "AllSaints",            label: "All Saints",                    selected: true }),
+    ]);
 
     static mergeOptions(customOptions) {
         if (!Array.isArray(customOptions) || customOptions.length === 0) {
-            return HolydaysOfObligationInput.BASE_OPTIONS;
+            return [...HolydaysOfObligationInput.BASE_OPTIONS];
         }
+        customOptions.forEach((o, i) => {
+            if (!o || typeof o.value !== 'string' || typeof o.label !== 'string' || typeof o.selected !== 'boolean') {
+                throw new Error(`Invalid option at index ${i}`);
+            }
+        });
 
         // Convert custom options into a map for quick lookup
         const customMap = new Map(customOptions.map(opt => [opt.value, opt]));
@@ -39,7 +44,7 @@ export default class HolydaysOfObligationInput extends SelectInput {
     }
 
     setOptions(options) {
-        console.info('setting holy days of obligation options:', options);
+        //console.info('setting holy days of obligation options:', options);
         this.#options = Object.freeze(HolydaysOfObligationInput.mergeOptions(options));
         // Clear existing options
         while (this._domElement.firstChild) {
@@ -52,6 +57,7 @@ export default class HolydaysOfObligationInput extends SelectInput {
             optionElement.title = value;
             optionElement.textContent = label;
             if (selected) {
+                // Prefer the 'selected' attribute over selected state so that the VirtualSelect can pick it up
                 optionElement.setAttribute('selected', 'selected');
             }
             this._domElement.appendChild(optionElement);
@@ -63,13 +69,12 @@ export default class HolydaysOfObligationInput extends SelectInput {
     }
 
     /**
-     * Constructs an HolydaysOfObligationInput object.
+     * Constructs a HolydaysOfObligationInput object.
      *
      * @param {Array<{value:string,label:string,selected:boolean}>} options - An array of objects where each object has the following properties:
      *   - value: The value attribute for the option element.
      *   - label: The text content for the option element.
      *   - selected: A boolean indicating whether the option is selected by default (i.e. whether the liturgical event is celebrated as a holy day of obligation or not).
-     * @throws {Error} Throws an error if the locale is null or not an instance of Intl.Locale.
      *
      * This constructor initializes the holy days of obligation input select element, setting its name, id, and
      * label text content, with the multiple attribute set to true.

--- a/src/ApiOptions/Input/Input.js
+++ b/src/ApiOptions/Input/Input.js
@@ -111,18 +111,57 @@ export default class Input {
 
     /**
      * @param {string} [element='select'] - The element to create as the input element.
-     *     Valid values are: select, input\[type="number"\].
+     *     Valid values are: `select`, `input`.
+     * @param {object} [attributes={multiple: false}] - Key-value pairs of attributes to set on the element.
+     *     When the element is `input`, the only current supported attribute is `type` with a value of `number` (which will produce an `input[type="number"]` element).
+     *     When the element is `select`, the `multiple` attribute can be set to `true` to create a multi-select element.
      * @throws {Error} If the element parameter is not a string or is not one of the valid values.
      */
-    constructor(element = 'select') {
-        if (false === ['select', 'input[type="number"]'].includes(element)) {
-            throw new Error('Invalid element parameter: ' + element + ', valid values are: select, input[type="number"]');
+    constructor(element = 'select', attributes = {multiple: false}) {
+        if (false === ['select', 'input'].includes(element)) {
+            throw new Error('Invalid `element` parameter: ' + element + ', valid values are: `select` and `input`');
         }
-        const parseType = /^(.*?)(\[type="(.*?)"\])?$/.exec(element);
-        this.#domElement = document.createElement(parseType[1]);
-        if (parseType[3] !== undefined) {
-            this.#domElement.setAttribute('type', parseType[3]);
+        if (typeof element !== 'string') {
+            throw new Error('Invalid type for element parameter, must be of type string but found type: ' + typeof element);
         }
+        if (typeof attributes !== 'undefined' && typeof attributes !== 'object') {
+            throw new Error('Invalid type for attributes parameter, when set it must be of type object but found type: ' + typeof attributes);
+        }
+        switch (element) {
+            case 'select':
+                if (typeof attributes.multiple !== 'undefined') {
+                    if (typeof attributes.multiple !== 'boolean') {
+                        throw new Error('Invalid type for multiple attribute, when set it must be of type boolean but found type: ' + typeof attributes.multiple);
+                    }
+                }
+                break;
+            case 'input':
+                if (typeof attributes.type !== 'undefined') {
+                    if (typeof attributes.type !== 'string') {
+                        throw new Error('Invalid type for type attribute, when set it must be of type string but found type: ' + typeof attributes.type);
+                    }
+                    if (false === ['number'].includes(attributes.type)) {
+                        throw new Error('Invalid type attribute for input element: ' + attributes.type + ', valid values are: `number`');
+                    }
+                }
+                break;
+        }
+        this.#domElement = document.createElement(element);
+        if (attributes !== undefined) {
+            switch (element) {
+                case 'select':
+                    if (attributes.multiple === true) {
+                        this.#domElement.setAttribute('multiple', 'multiple');
+                    }
+                    break;
+                case 'input':
+                    if (attributes.type !== undefined && attributes.type === 'number') {
+                        this.#domElement.setAttribute('type', 'number');
+                    }
+                    break;
+            }
+        }
+
         if (Input.#globalInputClass !== null) {
             this.#domElement.className = Input.#globalInputClass;
         }
@@ -168,6 +207,7 @@ export default class Input {
         }
         this.#domElement.id = id;
         this.#idSet = true;
+        this.#labelElement.htmlFor = this.#domElement.id;
         return this;
     }
 

--- a/src/ApiOptions/Input/Input.js
+++ b/src/ApiOptions/Input/Input.js
@@ -118,25 +118,25 @@ export default class Input {
      * @throws {Error} If the element parameter is not a string or is not one of the valid values.
      */
     constructor(element = 'select', attributes = {multiple: false}) {
-        if (false === ['select', 'input'].includes(element)) {
-            throw new Error('Invalid `element` parameter: ' + element + ', valid values are: `select` and `input`');
-        }
         if (typeof element !== 'string') {
             throw new Error('Invalid type for element parameter, must be of type string but found type: ' + typeof element);
         }
-        if (typeof attributes !== 'undefined' && typeof attributes !== 'object') {
+        if (false === ['select', 'input'].includes(element)) {
+            throw new Error('Invalid `element` parameter: ' + element + ', valid values are: `select` and `input`');
+        }
+        if (attributes !== undefined && (attributes === null || typeof attributes !== 'object')) {
             throw new Error('Invalid type for attributes parameter, when set it must be of type object but found type: ' + typeof attributes);
         }
         switch (element) {
             case 'select':
-                if (typeof attributes.multiple !== 'undefined') {
+                if (attributes && typeof attributes.multiple !== 'undefined') {
                     if (typeof attributes.multiple !== 'boolean') {
                         throw new Error('Invalid type for multiple attribute, when set it must be of type boolean but found type: ' + typeof attributes.multiple);
                     }
                 }
                 break;
             case 'input':
-                if (typeof attributes.type !== 'undefined') {
+                if (attributes && typeof attributes.type !== 'undefined') {
                     if (typeof attributes.type !== 'string') {
                         throw new Error('Invalid type for type attribute, when set it must be of type string but found type: ' + typeof attributes.type);
                     }
@@ -147,10 +147,10 @@ export default class Input {
                 break;
         }
         this.#domElement = document.createElement(element);
-        if (attributes !== undefined) {
+        if (attributes && typeof attributes === 'object') {
             switch (element) {
                 case 'select':
-                    if (attributes.multiple === true) {
+                    if (attributes.multiple !== undefined && attributes.multiple === true) {
                         this.#domElement.setAttribute('multiple', 'multiple');
                     }
                     break;
@@ -321,11 +321,19 @@ export default class Input {
      * if the method is called more than once since the content can only be set once.
      *
      * @param {string|null} contents - The content to be set after the label element.
-     *                                 If null, any existing content is cleared.
      * @throws {Error} If content is attempted to be set more than once.
-     * @returns {CalendarSelect} The current instance for method chaining.
+     * @returns {Input} The current instance for method chaining.
      */
     labelAfter( contents = '' ) {
+        if (this.#labelAfter !== null) {
+            //console.error('Label after content has already been set on Input instance.');
+            //console.error(this);
+            throw new Error('labelAfter content has already been set on Input instance.');
+        }
+        if (contents === null) {
+            this.#labelAfter = null;
+            return this;
+        }
         // remove php tags and script tags from contents
         // the regex is doing the following:
         //  - `<\?(?:php)?` matches the start of a php tag, optionally with the word "php" after the "?"
@@ -335,9 +343,10 @@ export default class Input {
         //  - `<script(.*?)>.*?<\/script>` matches the start of a script tag, any attributes, the contents of the script tag, and the end of the script tag
         //  - `g` flag makes the regex replacement global, so it will replace all occurrences of the regex, not just the first one
         contents = contents.replace(/<\?(?:php)?|\?>|<script(.*?)>.*?<\/script>/g, '');
-
-        const fragment = document.createRange().createContextualFragment(contents);
-        this.#labelAfter = fragment;
+        if (contents !== '') {
+            const fragment = document.createRange().createContextualFragment(contents);
+            this.#labelAfter = fragment;
+        }
         return this;
     }
 

--- a/src/ApiOptions/Input/Input.js
+++ b/src/ApiOptions/Input/Input.js
@@ -1,20 +1,27 @@
 import Utils from '../../Utils.js';
 
 export default class Input {
+    /** @type {string | null} */
     static #globalInputClass   = null;
+    /** @type {string | null} */
     static #globalLabelClass   = null;
+    /** @type {string | null} */
     static #globalWrapper      = null;
+    /** @type {string | null} */
     static #globalWrapperClass = null;
     /** @type {HTMLSelectElement | HTMLInputElement | null} */
     #domElement       = null;
+    /** @type {HTMLElement|null} */
+    #labelElement     = null;
+    /** @type {DocumentFragment|null} */
+    #labelAfter       = null;
+    /** @type {HTMLElement|null} */
+    #wrapperElement   = null;
     #idSet            = false;
     #nameSet          = false;
     #classSet         = false;
     #dataSet          = false;
-    #labelElement     = null;
     #labelClassSet    = false;
-    #labelAfter       = null;
-    #wrapperElement   = null;
     #hasWrapper       = false;
     #wrapperClassSet  = false;
     #defaultValue    = '';
@@ -530,13 +537,28 @@ export default class Input {
         else {
             throw new Error('Input.appendTo: Invalid type for elementSelector, must be either a valid CSS selector or an instance of HTMLElement but found type: ' + typeof elementSelector);
         }
-        if (null !== this._wrapperElement) {
-            this._wrapperElement.appendChild(this._labelElement);
-            this._wrapperElement.appendChild(this._domElement);
-            domNode.appendChild(this._wrapperElement);
-        } else {
-            domNode.appendChild(this._labelElement);
-            domNode.appendChild(this._domElement);
+        if (this._labelAfter instanceof DocumentFragment) {
+            // If wrapper, we append after input inside wrapper; otherwise after input in domNode
+            if (null !== this._wrapperElement) {
+                this._wrapperElement.appendChild(this._labelElement);
+                this._wrapperElement.appendChild(this._domElement);
+                this._wrapperElement.appendChild(this._labelAfter);
+                domNode.appendChild(this._wrapperElement);
+            } else {
+                domNode.appendChild(this._labelElement);
+                domNode.appendChild(this._domElement);
+                domNode.appendChild(this._labelAfter);
+            }
+        }
+        else {
+            if (null !== this._wrapperElement) {
+                this._wrapperElement.appendChild(this._labelElement);
+                this._wrapperElement.appendChild(this._domElement);
+                domNode.appendChild(this._wrapperElement);
+            } else {
+                domNode.appendChild(this._labelElement);
+                domNode.appendChild(this._domElement);
+            }
         }
     }
 
@@ -551,11 +573,9 @@ export default class Input {
     }
 
     /**
-     * A set of classes that are currently applied to the input element.
+     * Whether or not the class has been set.
      *
-     * This is a Set of strings, where each string is a class name.
-     *
-     * @type {Set<string>}
+     * @returns {boolean}
      * @readonly
      */
     get _classSet() {
@@ -565,7 +585,7 @@ export default class Input {
     /**
      * The label element.
      *
-     * @type {HTMLLabelElement}
+     * @returns {HTMLLabelElement}
      * @readonly
      */
     get _labelElement() {
@@ -573,9 +593,9 @@ export default class Input {
     }
 
     /**
-     * A set of classes to apply to the label element.
+     * Whether or not the label class has been set.
      *
-     * @type {Set<string>}
+     * @returns {boolean}
      * @readonly
      */
     get _labelClassSet() {
@@ -585,7 +605,7 @@ export default class Input {
     /**
      * The element to insert after the label element.
      *
-     * @type {DocumentFragment|null}
+     * @returns {DocumentFragment|null}
      * @readonly
      */
     get _labelAfter() {
@@ -595,7 +615,7 @@ export default class Input {
     /**
      * The wrapper element.
      *
-     * @type {HTMLElement|null}
+     * @returns {HTMLElement|null}
      * @readonly
      */
     get _wrapperElement() {
@@ -603,9 +623,9 @@ export default class Input {
     }
 
     /**
-     * The set of classes to be applied to the wrapper element.
+     * Whether or not the wrapper class has been set.
      *
-     * @type {Set<string>}
+     * @returns {boolean}
      * @readonly
      */
     get _wrapperClassSet() {
@@ -615,7 +635,7 @@ export default class Input {
     /**
      * The default value of the input element, set with the defaultValue() method.
      *
-     * @type {string}
+     * @returns {string}
      * @readonly
      */
     get _defaultValue() {
@@ -625,7 +645,7 @@ export default class Input {
     /**
      * Whether a wrapper element has been set.
      *
-     * @type {boolean}
+     * @returns {boolean}
      * @readonly
      */
     get _hasWrapper() {

--- a/src/ApiOptions/Input/LocaleInput.js
+++ b/src/ApiOptions/Input/LocaleInput.js
@@ -26,6 +26,7 @@ export default class LocaleInput extends SelectInput {
         this._domElement.name = 'locale';
         this._domElement.id = 'locale';
         this._labelElement.textContent = 'locale';
+        this._labelElement.htmlFor = this._domElement.id;
         if (ApiClient._metadata === null) {
             throw new Error('ApiClient has not yet been initialized. Please initialize with `ApiClient.init().then(() => { ... })`, and handle the LocaleInput instances within the callback.');
         }

--- a/src/ApiOptions/Input/NumberInput.js
+++ b/src/ApiOptions/Input/NumberInput.js
@@ -10,6 +10,6 @@ export default class NumberInput extends Input {
      * @throws {Error} If the element parameter is not a string or is not one of the valid values.
      */
     constructor() {
-        super('input[type="number"]');
+        super('input', {type: 'number'});
     }
 }

--- a/src/ApiOptions/Input/SelectInput.js
+++ b/src/ApiOptions/Input/SelectInput.js
@@ -7,8 +7,9 @@ export default class SelectInput extends Input {
      *
      * This constructor calls the parent Input class constructor,
      * specifying 'select' as the input element type.
+     * @param {boolean} [multiple=false] - Whether the select input allows multiple selections.
      */
-    constructor() {
-        super('select');
+    constructor(multiple = false) {
+        super('select', {multiple: multiple});
     }
 }

--- a/src/ApiOptions/Input/YearInput.js
+++ b/src/ApiOptions/Input/YearInput.js
@@ -17,6 +17,7 @@ export default class YearInput extends NumberInput {
         this._domElement.name = 'year';
         this._domElement.id = 'year';
         this._labelElement.textContent = 'year';
+        this._labelElement.htmlFor = this._domElement.id;
         this._domElement.min = 1970;
         this._domElement.max = 9999;
         this._domElement.step = 1;

--- a/src/ApiOptions/Input/YearTypeInput.js
+++ b/src/ApiOptions/Input/YearTypeInput.js
@@ -22,6 +22,7 @@ export default class YearTypeInput extends SelectInput {
         this._domElement.name = 'year_type';
         this._domElement.id = 'year_type';
         this._labelElement.textContent = 'year_type';
+        this._labelElement.htmlFor = this._domElement.id;
         if (locale === null) {
             throw new Error('Locale cannot be null.');
         }

--- a/src/ApiOptions/Input/index.js
+++ b/src/ApiOptions/Input/index.js
@@ -4,6 +4,7 @@ import CorpusChristiInput from './CorpusChristiInput.js';
 import EpiphanyInput from './EpiphanyInput.js';
 import LocaleInput from './LocaleInput.js';
 import EternalHighPriestInput from './EternalHighPriestInput.js';
+import HolydaysOfObligationInput from './HolydaysOfObligation.js';
 import YearInput from './YearInput.js';
 import YearTypeInput from './YearTypeInput.js';
 import CalendarPathInput from './CalendarPathInput.js';
@@ -15,6 +16,7 @@ export {
     EpiphanyInput,
     LocaleInput,
     EternalHighPriestInput,
+    HolydaysOfObligationInput,
     YearInput,
     YearTypeInput,
     CalendarPathInput

--- a/src/CalendarSelect/CalendarSelect.js
+++ b/src/CalendarSelect/CalendarSelect.js
@@ -53,51 +53,6 @@ export default class CalendarSelect {
     #nameSet                              = false;
     #allowNull                            = false;
 
-    /**
-     * Validates if the given class name adheres to standard CSS class naming conventions.
-     *
-     * The regex pattern used to validate class names:
-     *   - `^` asserts the start of a line
-     *   - `(?!\d|--|-?\d)` is a negative lookahead that prevents the class name
-     *     from starting with a digit, or a sequence of dashes, or a number with a leading dash
-     *   - `[a-zA-Z_-]` matches any character that is a letter, a dash or an underscore
-     *   - `[a-zA-Z\d_-]{1,}` matches any alphanumeric character, a dash or an underscore at least once
-     *   - `$` asserts the end of a line
-     *
-     * @param {string} className - The class name to validate.
-     * @returns {boolean} True if the class name is valid, false otherwise.
-     * @private
-     * @static
-     */
-    static #isValidClassName(className) {
-        const pattern = /^(?!\d|--|-?\d)[a-zA-Z_-][a-zA-Z\d_-]{1,}$/;
-        return pattern.test(className);
-    }
-
-    /**
-     * Validates if the given ID adheres to HTML and CSS ID naming conventions.
-     *
-     * The regex pattern used to validate IDs:
-     *   - `^` asserts the start of a line
-     *   - `(?!\d|--|-?\d)` is a negative lookahead that prevents the ID
-     *     from starting with a digit, a sequence of dashes, or a number with a leading dash
-     *   - `(?:[_-][a-zA-Z][\w\-]*|[a-zA-Z][\w\-]*)` matches either a sequence starting with an underscore or dash
-     *     followed by a letter and zero or more word characters or dashes,
-     *     or it matches a letter followed by zero or more word characters or dashes
-     *   - `$` asserts the end of a line
-     *
-     * Note: While ID attribute values can contain any Unicode character,
-     *       they must be valid CSS identifiers when used in CSS selectors or with JavaScript methods like `querySelector`.
-     *
-     * @param {string} id - The ID to validate.
-     * @returns {boolean} True if the ID is valid, false otherwise.
-     * @private
-     * @static
-     */
-    static #isValidId(id) {
-        const pattern = /^(?!\d|--|-?\d)(?:[_-][a-zA-Z][\w\-]*|[a-zA-Z][\w\-]*)$/;
-        return pattern.test(id);
-    }
 
     /**
      * Returns true if we have already stored a national calendar with dioceses for the given nation,
@@ -164,18 +119,18 @@ export default class CalendarSelect {
      * Constructor for the CalendarSelect class.
      *
      * @param {Object|string} [options] - The options object or locale string. An options object can have the following properties:
-     *                                  - locale: The locale to use for the CalendarSelect UI elements.
-     *                                  - id: The ID of the CalendarSelect element.
-     *                                  - class: The class name for the CalendarSelect element.
-     *                                  - name: The name for the CalendarSelect element.
-     *                                  - filter: The CalendarSelectFilter to apply to the CalendarSelect element.
-     *                                  - after: an html string to append after the CalendarSelect element.
-     *                                  - allowNull: a boolean to indicate if the CalendarSelect element should allow null values.
-     *                                  - disabled: a boolean to indicate if the CalendarSelect element should be disabled.
-     *                                  - label: The label for the CalendarSelect element (an object with a `text` property, and optionally `class` and `id` properties).
-     *                                  - wrapper: The wrapper for the CalendarSelect element (an object with an `as` property, and optionally `class` and `id` properties).
-     *                                  If a string is passed, it is expected to be the locale code to use for the CalendarSelect UI elements.
-     *                                  The locale should be a valid string that can be parsed by the Intl.getCanonicalLocales function.
+     *                                  - `locale`: The locale to use for the `CalendarSelect` UI elements.
+     *                                  - `id`: The ID of the `CalendarSelect` DOM input.
+     *                                  - `class`: The class name for the `CalendarSelect` DOM input.
+     *                                  - `name`: The name for the `CalendarSelect` DOM input.
+     *                                  - `filter`: The `CalendarSelectFilter` to apply to the `CalendarSelect` component.
+     *                                  - `after`: an html string to append after the `CalendarSelect` element.
+     *                                  - `allowNull`: a boolean to indicate whether the `CalendarSelect` element should allow `null` values.
+     *                                  - `disabled`: a boolean to indicate whether the `CalendarSelect` DOM input element should be disabled.
+     *                                  - `label`: The label for the `CalendarSelect` DOM input (an object with a `text` property, and optionally `class` and `id` properties).
+     *                                  - `wrapper`: The wrapper for the `CalendarSelect` component (an object with an `as` property, and optionally `class` and `id` properties).
+     *                                  If a string is passed, it is expected to be the locale code to use for the `CalendarSelect` UI elements.
+     *                                  The locale should be a valid ISO 639-1 code that can be parsed by the Intl.getCanonicalLocales function.
      *                                  If the locale string contains an underscore, the underscore will be replaced with a hyphen.
      *
      * @throws {Error} If the locale is invalid.
@@ -184,7 +139,7 @@ export default class CalendarSelect {
         if (typeof options === 'string') {
             options = { locale: options };
         }
-        else if (null === options) {
+        else if (null === options || typeof options === 'undefined') {
             options = { locale: 'en' };
         }
         else if (typeof options !== 'object' || Array.isArray(options)) {
@@ -412,11 +367,9 @@ export default class CalendarSelect {
      * and assigned to the element. If the class name is an empty string, the
      * class attribute is removed.
      *
-     * @param {string} className - A space-separated string of class names to be
-     * assigned to the DOM element.
-     * @throws {Error} If the className is not a string, or if any class name is
-     * invalid.
-     * @returns {CalendarSelect} The current CalendarSelect instance for chaining.
+     * @param {string} className - A space-separated string of class names to be assigned to the DOM element.
+     * @throws {Error} If the className is not a string, or if any class name is invalid.
+     * @returns {CalendarSelect} The current `CalendarSelect` instance for chaining.
      */
     class( className ) {
         if ( typeof className !== 'string' ) {
@@ -439,7 +392,7 @@ export default class CalendarSelect {
     }
 
     /**
-     * Sets the id attribute of the select element.
+     * Sets the `id` attribute of the select element.
      *
      * Validates the input id to ensure it is a string and conforms to
      * HTML id attribute naming conventions. If the id is valid, it is sanitized
@@ -478,7 +431,7 @@ export default class CalendarSelect {
     }
 
     /**
-     * Sets the name attribute of the select element.
+     * Sets the `name` attribute of the select element.
      *
      * Validates the input name to ensure it is a string. If the name is valid,
      * it is sanitized and assigned to the element. If the name is an empty
@@ -503,7 +456,7 @@ export default class CalendarSelect {
     }
 
     /**
-     * Configures the label element for the CalendarSelect instance.
+     * Configures the `label` element for the `CalendarSelect` DOM input.
      *
      * If label options are not provided, the label will not be created and
      * any existing label will be removed. If an object is provided, it

--- a/src/CalendarSelect/CalendarSelect.js
+++ b/src/CalendarSelect/CalendarSelect.js
@@ -864,17 +864,17 @@ export default class CalendarSelect {
     insertAfter( element ) {
         let domNode;
         if (typeof element === 'string') {
-            console.log(`element is a CSS selector: ${element}`);
+            //console.log(`element is a CSS selector: ${element}`);
             domNode = Utils.validateElementSelector( element );
         }
         else if (element instanceof HTMLElement) {
-            console.log(`element is an HTMLElement:`, element);
+            //console.log(`element is an HTMLElement:`, element);
             domNode = element;
         }
         else if (element instanceof Input) {
-            console.log(`element is an ApiOptions Input:`, element);
+            //console.log(`element is an ApiOptions Input:`, element);
             if (element._hasWrapper) {
-                console.log(`element has a wrapper element:`, element._wrapperElement);
+                //console.log(`element has a wrapper element:`, element._wrapperElement);
                 domNode = element._wrapperElement;
             } else {
                 domNode = element._domElement;
@@ -883,7 +883,7 @@ export default class CalendarSelect {
         else {
             throw new Error('CalendarSelect.insertAfter: parameter must be a valid CSS selector or an instance of HTMLElement');
         }
-        console.log(`domNode:`, domNode);
+        //console.log(`domNode:`, domNode);
 
         if ( this.#hasWrapper ) {
             domNode.insertAdjacentElement( 'afterend', this.#wrapperElement );

--- a/src/Enums.js
+++ b/src/Enums.js
@@ -86,4 +86,56 @@ const YearType = Object.freeze({
     CIVIL: 'CIVIL'
 });
 
-export { Grouping, ColumnOrder, Column, ColorAs, DateFormat, GradeDisplay, ApiOptionsFilter, CalendarSelectFilter, YearType };
+const monthsLatin = Object.freeze([
+    '', // Placeholder for 0 index
+    'Ianuarius', 'Februarius', 'Martius', 'Aprilis', 'Maius', 'Iunius',
+    'Iulius', 'Augustus', 'September', 'October', 'November', 'December'
+]);
+
+const daysLatin = Object.freeze({
+    'ecclesiastical': [
+        'Dominica',    // Sunday
+        'Feria II',    // Monday
+        'Feria III',   // Tuesday
+        'Feria IV',    // Wednesday
+        'Feria V',     // Thursday
+        'Feria VI',    // Friday
+        'Sabbato'      // Saturday
+    ],
+    'civil': [
+        'Dies Solis',    // Sunday
+        'Dies Lunæ',     // Monday
+        'Dies Martis',   // Tuesday
+        'Dies Mercurii', // Wednesday
+        'Dies Iovis',    // Thursday
+        'Dies Veneris',  // Friday
+        'Dies Saturni'   // Saturday
+    ]
+});
+
+/**
+ * @enum {{
+ *   ECCLESIASTICAL: {month: function(number): string, dayOfTheWeek: function(number): string},
+ *   CIVIL: {month: function(number): string, dayOfTheWeek: function(number): string}
+ * }}
+ */
+const LatinInterface = Object.freeze({
+    ECCLESIASTICAL: {
+        month: function(month) {
+            return monthsLatin[month] || '';
+        },
+        dayOfTheWeek: function(day) {
+            return daysLatin.ecclesiastical[day] || '';
+        }
+    },
+    CIVIL: {
+        month: function(month) {
+            return monthsLatin[month] || '';
+        },
+        dayOfTheWee: function(day) {
+            return daysLatin.civil[day] || '';
+        }
+    }
+});
+
+export { Grouping, ColumnOrder, Column, ColorAs, DateFormat, GradeDisplay, ApiOptionsFilter, CalendarSelectFilter, YearType, LatinInterface };

--- a/src/Enums.js
+++ b/src/Enums.js
@@ -132,7 +132,7 @@ const LatinInterface = Object.freeze({
         month: function(month) {
             return monthsLatin[month] || '';
         },
-        dayOfTheWee: function(day) {
+        dayOfTheWeek: function(day) {
             return daysLatin.civil[day] || '';
         }
     }

--- a/src/LiturgyOfTheDay/LiturgyOfTheDay.js
+++ b/src/LiturgyOfTheDay/LiturgyOfTheDay.js
@@ -506,9 +506,9 @@ export default class LiturgyOfTheDay {
             if (!data.hasOwnProperty('settings') || !data.hasOwnProperty('metadata') || !data.hasOwnProperty('messages')) {
                 throw new Error('LiturgyOfTheDay: data received in `calendarFetched` event should have litcal, settings, metadata and messages properties');
             }
-            const todaysTimestamp = this.#date.getTime() / 1000;
+            const todaysTimestamp = this.#date.getTime();
             const todaysEvents = data.litcal.filter(event => {
-                return event.date === todaysTimestamp;
+                return new Date(event.date).getTime() === todaysTimestamp;
             });
             console.log('todaysEvents: ', todaysEvents);
             this.#updateEventDetails(todaysEvents);

--- a/src/WebCalendar/WebCalendar.js
+++ b/src/WebCalendar/WebCalendar.js
@@ -1050,13 +1050,14 @@ export default class WebCalendar {
         // Second column is Date
         let dateStr = '';
         switch (this.#baseLocale) {
-            case 'la':
-                let dayOfTheWeek = litevent.date.getDay(); // 0-Sunday to 6-Saturday
-                let dayOfTheWeekLatin = this.#latinInterface.dayOfTheWeek(dayOfTheWeek);
-                let month = litevent.date.getMonth() + 1; // 0-January to 11-December
-                let monthLatin = this.#latinInterface.month(month);
+            case 'la': {
+                const dayOfTheWeek = litevent.date.getDay(); // 0-Sunday to 6-Saturday
+                const dayOfTheWeekLatin = this.#latinInterface.dayOfTheWeek(dayOfTheWeek);
+                const month = (litevent.date.getMonth() + 1); // 0-January to 11-December
+                const monthLatin = this.#latinInterface.month(month);
                 dateStr = `${dayOfTheWeekLatin} ${litevent.date.getDate()} ${monthLatin} ${litevent.date.getFullYear()}`;
                 break;
+            }
             default:
                 dateStr = this.#dateFmt.format(litevent.date);
         }

--- a/src/WebCalendar/WebCalendar.js
+++ b/src/WebCalendar/WebCalendar.js
@@ -1,4 +1,4 @@
-import { Grouping, ColumnOrder, Column, ColorAs, DateFormat, GradeDisplay } from '../Enums.js';
+import { Grouping, ColumnOrder, Column, ColorAs, DateFormat, GradeDisplay, LatinInterface } from '../Enums.js';
 import ColumnSet from './ColumnSet.js';
 import ApiClient from '../ApiClient/ApiClient.js';
 import Messages from '../Messages.js';
@@ -69,6 +69,12 @@ export default class WebCalendar {
      */
     #gradeDisplay = GradeDisplay.FULL;
 
+    /**
+     * @type {LatinInterface}
+     * @private
+     */
+    #latinInterface = LatinInterface.ECCLESIASTICAL;
+
     #removeHeaderRow = false;
 
     #removeCaption = false;
@@ -106,41 +112,6 @@ export default class WebCalendar {
      */
     static #HIGH_CONTRAST = Object.freeze(['purple', 'red', 'green']);
 
-    /**
-     * @type {['dies Solis', 'dies Lunæ', 'dies Martis', 'dies Mercurii', 'dies Iovis', 'dies Veneris', 'dies Saturni']}
-     * @private
-     * @readonly
-     */
-    static #DAYS_OF_THE_WEEK_LATIN = Object.freeze([
-        "dies Solis",
-        "dies Lunæ",
-        "dies Martis",
-        "dies Mercurii",
-        "dies Iovis",
-        "dies Veneris",
-        "dies Saturni"
-    ]);
-
-    /**
-     * @type {['', 'Ianuarius', 'Februarius', 'Martius', 'Aprilis', 'Maius', 'Iunius', 'Iulius', 'Augustus', 'September', 'October', 'November', 'December']}
-     * @private
-     * @readonly
-     */
-    static #MONTHS_LATIN = Object.freeze([
-        "",
-        "Ianuarius",
-        "Februarius",
-        "Martius",
-        "Aprilis",
-        "Maius",
-        "Iunius",
-        "Iulius",
-        "Augustus",
-        "September",
-        "October",
-        "November",
-        "December"
-    ]);
 
     /**
      * @type {['', 'I', 'II', 'III', 'IV']}
@@ -315,6 +286,9 @@ export default class WebCalendar {
         }
         if (options.hasOwnProperty('gradeDisplay')) {
             this.gradeDisplay(options.gradeDisplay);
+        }
+        if (options.hasOwnProperty('latinInterface')) {
+            this.latinInterface(options.latinInterface);
         }
     }
 
@@ -664,6 +638,28 @@ export default class WebCalendar {
     }
 
     /**
+     * Sets the Latin interface for the WebCalendar instance.
+     *
+     * The Latin interface determines which set of month and weekday names to use
+     * for the calendar. The following options are supported:
+     * - LatinInterface.ECCLESIASTICAL: month and weekday names are based on the ecclesiastical calendar
+     * - LatinInterface.CIVIL: month and weekday names are based on the civil calendar
+     *
+     * The default is LatinInterface.ECCLESIASTICAL.
+     *
+     * @param {LatinInterface} latinInterface The Latin interface to use.
+     * @throws {Error} If the input is not a valid LatinInterface.
+     * @returns {WebCalendar} The current instance of the class.
+     */
+    latinInterface(latinInterface) {
+        if (!Object.values(LatinInterface).includes(latinInterface)) {
+            throw new Error('Invalid Latin interface: ' + latinInterface);
+        }
+        this.#latinInterface = latinInterface;
+        return this;
+    }
+
+    /**
      * Sets the locale for the WebCalendar instance.
      *
      * The locale determines the language and regional settings for date formatting
@@ -998,7 +994,7 @@ export default class WebCalendar {
                 this.#handleSeasonColorForColumn(seasonColor, firstColCell, Column.MONTH);
                 this.#handleEventColorForColumn(litevent.color, firstColCell, Column.MONTH);
                 const textNode = this.#baseLocale === 'la'
-                    ? WebCalendar.#MONTHS_LATIN[litevent.date.getMonth() + 1].toUpperCase()
+                    ? this.#latinInterface.month(litevent.date.getMonth() + 1).toUpperCase()
                     : this.#monthFmt.format(litevent.date).toUpperCase();
                 const div = document.createElement('div');
                 div.appendChild(document.createTextNode(textNode));
@@ -1056,9 +1052,9 @@ export default class WebCalendar {
         switch (this.#baseLocale) {
             case 'la':
                 let dayOfTheWeek = litevent.date.getDay(); // 0-Sunday to 6-Saturday
-                let dayOfTheWeekLatin = WebCalendar.#DAYS_OF_THE_WEEK_LATIN[dayOfTheWeek];
+                let dayOfTheWeekLatin = this.#latinInterface.dayOfTheWeek(dayOfTheWeek);
                 let month = litevent.date.getMonth() + 1; // 0-January to 11-December
-                let monthLatin = WebCalendar.#MONTHS_LATIN[month];
+                let monthLatin = this.#latinInterface.month(month);
                 dateStr = `${dayOfTheWeekLatin} ${litevent.date.getDate()} ${monthLatin} ${litevent.date.getFullYear()}`;
                 break;
             default:
@@ -1404,7 +1400,7 @@ export default class WebCalendar {
                 throw new Error('WebCalendar: data received in `calendarFetched` event should have litcal, settings, metadata and messages properties');
             }
             data.litcal = data.litcal.map(event => {
-                event.date = new Date(event.date * 1000);
+                event.date = new Date(event.date);
                 return event;
             });
             this.#calendarData = data;

--- a/src/stories/0_Components/ApiOptions.stories.js
+++ b/src/stories/0_Components/ApiOptions.stories.js
@@ -63,7 +63,7 @@ const meta = {
         const container = document.createElement( 'div' );
         container.id = 'apiOptionsContainer';
 
-        if ( false === apiClient || false === apiClient instanceof ApiClient ) {
+        if ( false === apiClient || false === (apiClient instanceof ApiClient) ) {
             container.textContent = 'Error initializing the Liturgical Calendar API Client, check that the API is running at ' + ApiClient._apiUrl;
         } else {
             Input.setGlobalInputClass('unstyled');

--- a/src/stories/0_Components/LiturgyOfTheDayDiocesanCalendar.stories.js
+++ b/src/stories/0_Components/LiturgyOfTheDayDiocesanCalendar.stories.js
@@ -95,7 +95,7 @@ const meta = {
                     const ChristKing = data.litcal.find(event => {
                         return event.event_key === 'ChristKing';
                     });
-                    const ChristKingDate = new Date(ChristKing.date * 1000);
+                    const ChristKingDate = new Date(ChristKing.date);
                     const Saturday34OrdinaryTimeDate = new Date(ChristKingDate.getTime());
                     Saturday34OrdinaryTimeDate.setDate(ChristKingDate.getDate() + 6);
                     const MondayFirstWeekAdventDate = new Date(ChristKingDate.getTime());

--- a/src/stories/0_Components/LiturgyOfTheDayNationalCalendar.stories.js
+++ b/src/stories/0_Components/LiturgyOfTheDayNationalCalendar.stories.js
@@ -100,7 +100,7 @@ const meta = {
                     const ChristKing = data.litcal.find(event => {
                         return event.event_key === 'ChristKing';
                     });
-                    const ChristKingDate = new Date(ChristKing.date * 1000);
+                    const ChristKingDate = new Date(ChristKing.date);
                     const Saturday34OrdinaryTimeDate = new Date(ChristKingDate.getTime());
                     Saturday34OrdinaryTimeDate.setDate(ChristKingDate.getDate() + 6);
                     const MondayFirstWeekAdventDate = new Date(ChristKingDate.getTime());

--- a/src/stories/1_CombinedComponents/CalendarSelectApiOptions.stories.js
+++ b/src/stories/1_CombinedComponents/CalendarSelectApiOptions.stories.js
@@ -73,7 +73,7 @@ const meta = {
         container.id = 'apiOptionsCalendarSelectContainer';
         container.classList.add('row');
 
-        if ( false === apiClient || false === apiClient instanceof ApiClient ) {
+        if ( false === apiClient || false === (apiClient instanceof ApiClient) ) {
             container.textContent = 'Error initializing the Liturgical Calendar API Client, check that the API is running at ' + ApiClient._apiUrl;
         } else {
             Input.setGlobalInputClass('form-select');

--- a/src/stories/1_CombinedComponents/CalendarSelectApiOptionsWebCalendar.stories.js
+++ b/src/stories/1_CombinedComponents/CalendarSelectApiOptionsWebCalendar.stories.js
@@ -76,6 +76,7 @@ const meta = {
         });
         apiClient.listenTo(calendarSelect).listenTo(apiOptions);
         webCalendar.listenTo(apiClient).attachTo(webCalendarContainer);
+        apiClient.fetchNationalCalendar('VA');
     }
     return container;
   },

--- a/src/stories/1_CombinedComponents/CalendarSelectWebCalendar.stories.js
+++ b/src/stories/1_CombinedComponents/CalendarSelectWebCalendar.stories.js
@@ -59,6 +59,7 @@ const meta = {
         });
         apiClient.listenTo(calendarSelect);
         webCalendar.listenTo(apiClient).attachTo(webCalendarContainer);
+        apiClient.fetchNationalCalendar('VA');
     }
     return container;
   },

--- a/src/stories/Configure.mdx
+++ b/src/stories/Configure.mdx
@@ -15,11 +15,11 @@ import Accessibility from "./assets/accessibility.png";
 import Theming from "./assets/theming.png";
 import AddonLibrary from "./assets/addon-library.png";
 
-export const RightArrow = () => <svg 
-    viewBox="0 0 14 14" 
-    width="8px" 
-    height="14px" 
-    style={{ 
+export const RightArrow = () => <svg
+    viewBox="0 0 14 14"
+    width="8px"
+    height="14px"
+    style={{
       marginLeft: '4px',
       display: 'inline-block',
       shapeRendering: 'inherit',

--- a/src/stories/webcalendar.css
+++ b/src/stories/webcalendar.css
@@ -99,11 +99,11 @@
 }
 
 #LitCalTable td.red {
-    background-color: lightpink;
+    background-color: lightrose;
     color: black;
 }
 
-#LitCalTable td.pink {
+#LitCalTable td.rose {
     background-color: mistyrose;
     color: black;
 }

--- a/src/stories/webcalendar.css
+++ b/src/stories/webcalendar.css
@@ -99,7 +99,7 @@
 }
 
 #LitCalTable td.red {
-    background-color: lightrose;
+    background-color: lightpink;
     color: black;
 }
 

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -3,7 +3,7 @@
  * @prop {string} event_key - The "key" or "tag" or "id" of the liturgical event
  * @prop {int} event_idx - The progressive index, one for each liturgical event
  * @prop {string} name - The name of the liturgical event according to the requested locale
- * @prop {Date|int} date - The date of the liturgical event
+ * @prop {Date|string} date - The date of the liturgical event
  * @prop {int} month - The month of the liturgical event
  * @prop {string} month_long - The month of the liturgical event in the requested locale
  * @prop {string} month_short - The month of the liturgical event in the requested locale
@@ -19,15 +19,16 @@
  * @prop {string} grade_lcl - The liturgical grade of the liturgical event in the requested locale
  * @prop {string | null} grade_display - The liturgical grade of the liturgical event as it should be displayed
  * @prop {string} grade_abbr - The abbreviated form of the liturgical grade
- * @prop {string} [liturgical_year] - The liturgical cycle (festive A, B, or C; or weekday I or II) of the liturgical event
  * @prop {string} liturgical_season - The liturgical season of the liturgical event
  * @prop {string} liturgical_season_lcl - The liturgical season of the liturgical event in the requested locale
+ * @prop {string} [liturgical_year] - The liturgical cycle (festive A, B, or C; or weekday I or II) of the liturgical event
  * @prop {string} [is_vigil_for] - The liturgical event for which the current event is a Vigil Mass
  * @prop {boolean} [is_vigil_mass] - Will have a boolean value of 'true' if the event is a Vigil Mass for a Solemnity or Sunday
  * @prop {boolean} [has_vesper_i] - Will have a boolean value of 'true' if the expected First Vespers are confirmed
  * @prop {boolean} [has_vesper_ii] - Will have a boolean value of 'true' if the expected Second Vespers are confirmed
  * @prop {boolean} [has_vigil_mass] - Will have a boolean value of 'true' if the expected Vigil Mass is confirmed
  * @prop {string} [psalter_week] - The psalter week in which the liturgical event falls
+ * @prop {boolean} [holy_day_of_obligation] - Will have a boolean value of 'true' if the liturgical event is observed as a holy day of obligation
  * @prop {['mobile', 'fixed']} type - The type of the liturgical event
  */
 
@@ -42,6 +43,7 @@
  * @prop {['JSON', 'XML', 'YML', 'ICS']} return_type - The type of the response data
  * @prop {['LITURGICAL', 'CIVIL']} year_type - The type of the year whether it is liturgical or civil
  * @prop {boolean} eternal_high_priest - Whether the feast of the Eternal High Priest is celebrated
+ * @prop {object} [holydays_of_obligation] - An object where the keys are the event_keys of the liturgical events and the values are booleans indicating whether the liturgical event is observed as a holy day of obligation or not
  * @prop {string} [national_calendar] - The national calendar used for the calculation
  * @prop {string} [diocesan_calendar] - The diocesan calendar used for the calculation
  */

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -3,7 +3,7 @@
  * @prop {string} event_key - The "key" or "tag" or "id" of the liturgical event
  * @prop {int} event_idx - The progressive index, one for each liturgical event
  * @prop {string} name - The name of the liturgical event according to the requested locale
- * @prop {Date|string} date - The date of the liturgical event, either as a Date object or an ISO-8601 formatted string `YYYY-MM-DD`
+ * @prop {Date|string} date - The date of the liturgical event, either as a Date object or an RFC 3339 (ISO-8601) formatted string `YYYY-MM-DD`
  * @prop {int} month - The month of the liturgical event
  * @prop {string} month_long - The month of the liturgical event in the requested locale
  * @prop {string} month_short - The month of the liturgical event in the requested locale
@@ -37,7 +37,7 @@
  * @typedef {Object} CalendarSettings
  * @prop {number} year - The year for which the calendar is calculated
  * @prop {['JAN6', 'SUNDAY_JAN2_JAN8']} epiphany - When Epiphany is celebrated
- * @prop {['THURSDAY', 'SUNDAY"]} ascension - When the Ascension is celebrated
+ * @prop {['THURSDAY', 'SUNDAY']} ascension - When the Ascension is celebrated
  * @prop {['THURSDAY', 'SUNDAY']} corpus_christi - When Corpus Christi is celebrated
  * @prop {string} locale - The locale for the calendar
  * @prop {['JSON', 'XML', 'YML', 'ICS']} return_type - The type of the response data

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -3,7 +3,7 @@
  * @prop {string} event_key - The "key" or "tag" or "id" of the liturgical event
  * @prop {int} event_idx - The progressive index, one for each liturgical event
  * @prop {string} name - The name of the liturgical event according to the requested locale
- * @prop {Date|string} date - The date of the liturgical event
+ * @prop {Date|string} date - The date of the liturgical event, either as a Date object or an ISO-8601 formatted string `YYYY-MM-DD`
  * @prop {int} month - The month of the liturgical event
  * @prop {string} month_long - The month of the liturgical event in the requested locale
  * @prop {string} month_short - The month of the liturgical event in the requested locale
@@ -43,7 +43,7 @@
  * @prop {['JSON', 'XML', 'YML', 'ICS']} return_type - The type of the response data
  * @prop {['LITURGICAL', 'CIVIL']} year_type - The type of the year whether it is liturgical or civil
  * @prop {boolean} eternal_high_priest - Whether the feast of the Eternal High Priest is celebrated
- * @prop {object} [holydays_of_obligation] - An object where the keys are the event_keys of the liturgical events and the values are booleans indicating whether the liturgical event is observed as a holy day of obligation or not
+ * @prop {{ [event_key: string]: boolean }} [holydays_of_obligation] - Map of event_key → boolean indicating which liturgical events are observed as holy days of obligation
  * @prop {string} [national_calendar] - The national calendar used for the calculation
  * @prop {string} [diocesan_calendar] - The diocesan calendar used for the calculation
  */


### PR DESCRIPTION
Fixes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Virtual multi-select UI added across examples
  * Holydays of Obligation filter and input exposed
  * Latin interface (ecclesiastical/civil) added; YearType export noted
  * VS Code workspace recommendations and MDX server enabled

* **Bug Fixes / Accessibility**
  * Linked labels to inputs for improved accessibility
  * Date handling adjusted to millisecond timestamps for daily displays

* **Style**
  * Calendar color class renamed (pink → rose) and virtual-select styles added

* **Documentation**
  * README expanded with usage and export updates

* **Chores**
  * Package version bumped to 1.3.0
  * Updated npm publish workflow comment
<!-- end of auto-generated comment: release notes by coderabbit.ai -->